### PR TITLE
Fix mouse events

### DIFF
--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -574,12 +574,12 @@ class Shadertoy:
             if event["button"] == 1 or 1 in event["buttons"]:
                 _, _, x2, y2 = self._uniform_data["mouse"]
                 x1, y1 = event["x"], self.resolution[1] - event["y"]
-                self._uniform_data["mouse"] = x1, y1, x2, y2
+                self._uniform_data["mouse"] = x1, y1, abs(x2), -abs(y2)
 
         def on_mouse_down(event):
             if event["button"] == 1 or 1 in event["buttons"]:
                 x, y = event["x"], self.resolution[1] - event["y"]
-                self._uniform_data["mouse"] = (x, y, x, -y)
+                self._uniform_data["mouse"] = (x, y, abs(x), abs(y))
 
         def on_mouse_up(event):
             if event["button"] == 1 or 1 in event["buttons"]:

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -584,7 +584,7 @@ class Shadertoy:
         def on_mouse_up(event):
             if event["button"] == 1 or 1 in event["buttons"]:
                 x1, y1, x2, y2 = self._uniform_data["mouse"]
-                self._uniform_data["mouse"] = x1, y1, abs(x2), y2
+                self._uniform_data["mouse"] = x1, y1, -abs(x2), -abs(y2)
 
         self._canvas.add_event_handler(on_resize, "resize")
         self._canvas.add_event_handler(on_mouse_move, "pointer_move")


### PR DESCRIPTION
first issue in #11 

the mouse even is explained in example `shadertoy_glsl_mouse_event.py` as well as some information in the comments on the source: https://www.shadertoy.com/view/Mss3zH

there is two issues with the current implementation when comparing the online reference with the local example: 

1. while the mouse is down, the yellow line shows up. If you release - the yellow line should vanish. (fixed in first commit)
2. on "click" meaning ~~the first frame when you click a white circle will show up. (in progress)~~ a bit of a bodge where a click begins when you press the mouse button and ends when you move the mouse. This kind of resembles the behavior of the website when paused. 