### PR TITLE
Add basic common support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shadertoy implementation based on [wgpu-py](https://github.com/pygfx/wgpu-py).
 
 ## Introduction
 
-This library provides an easy to use python utility to run shader programs from the website [Shadertoy.com](https://www.shadertoy.com/). It provides the compability to let users copy code from the website directly and run it with the various [GUIs that are supported in wgpu-py](https://wgpu-py.readthedocs.io/en/stable/gui.html). Including Jupyter notebooks.     
+This library provides an easy to use python utility to run shader programs from the website [Shadertoy.com](https://www.shadertoy.com/). It provides the compatibility to let users copy code from the website directly and run it with the various [GUIs that are supported in wgpu-py](https://wgpu-py.readthedocs.io/en/stable/gui.html). Including Jupyter notebooks.     
 Shadertoys translated to wgsl are also supported using the uniforms `i_resolution`, `i_time`, etc. 
 
 This project is not affiliated with shadertoy.com.

--- a/examples/shadertoy_common.py
+++ b/examples/shadertoy_common.py
@@ -1,30 +1,137 @@
 from wgpu_shadertoy import Shadertoy
 
-# shader_source https://www.shadertoy.com/view/XcSXWD by Vipitis
+# shader source https://www.shadertoy.com/view/4l2BW3 by iq
+image_code = """
+// The MIT License
+// Copyright © 2018 Inigo Quilez
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-common_code = """
-// degree of red from 0.0 to 1.0 as a function
-vec3 getRed(float r){
-    return vec3(r, 0.0, 0.0);
+
+// This shader shows how to use the Common tab in Shadertoy: all tabs inherit the
+// code in the "Common" tab. In this case, that's used to get the Image and the
+// Sound shader to reuse the same music pattern to display the visuals and produce
+// the sound.
+
+
+float shape( in vec2 p, in float n, in float w, in float a )
+{    
+    float r = length(p);
+    float h = 0.7 + 
+              (26.0-n)*0.005*
+              sin(atan(p.y,p.x)*(2.0+floor(n/4.0))+2.0*iTime)*
+              sin((w-50.0)*a*0.2);
+    return h - r;
 }
 
-// solid green as a variable
-vec3 green = vec3(0.0, 1.0, 0.0);
-"""
-
-shader_code = """
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-    vec2 uv = (fragCoord - .5/iResolution.xy)/iResolution.y;
+    float n = patternNote( iTime );
+    float w = patternFreq( iTime );
+    float a = patternFrac( iTime );
 
-    vec3 col = getRed(fract(iTime));
-    col += green;
-    // Output to screen
+    vec2  p = (2.0*fragCoord-iResolution.xy) / iResolution.y;
+    
+    float e = 2.0/iResolution.y;
+    float f  = shape(p,n,w,a);
+    float fx = shape(p+vec2(e,0.0),n,w,a);
+    float fy = shape(p+vec2(0.0,e),n,w,a);
+    
+    float d = abs(f) / length( vec2(f-fx,f-fy) );
+    float q = smoothstep(1.0,2.0, d );
+    q *= 0.8 + 0.2*smoothstep(0.0,10.0, d );
+
+    vec3 col = vec3(1.0,0.8,0.6);
+    col.yz += 0.01*sin(p.x+sin(p.y+iTime));
+    col *= 1.0 - 0.3*length(p);
+    col *= 1.0 - 4.0*a*(1.0-a)*(1.0-q);
+
     fragColor = vec4(col,1.0);
+    
 }
 """
 
-shader = Shadertoy(shader_code, common=common_code, resolution=(800, 450))
+# wgpu currently throws error: 'wholeNotes' is invalid The type is not constructible
+# so the length of the array as been hardcoded in L74
+common_code = """
+// The MIT License
+// Copyright © 2018 Inigo Quilez
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// This shader shows how to use the Common tab in Shadertoy: all tabs inherit the
+// code in the "Common" tab. In this case, that's used to get the Image and the
+// Sound shader to reuse the same music pattern to display the visuals and produce
+// the sound.
+
+
+const float speed = 1.5;
+
+float patternFrac( float x )
+{
+    return fract(speed*x);
+}
+
+const int wholeNotes[7] = int[](0,2,4,5,7,9,11);
+
+float patternNote( float x )
+{
+    int noteID = int( 7.0+7.0*sin( floor(speed*x) ) );
+    return float( wholeNotes[noteID%7] + 12*(noteID/7) );
+}
+
+float patternFreq( float x )
+{
+    float f = patternNote(x);
+    return 55.0*pow(2.0,f/12.0);
+}
+"""
+
+# sound shaders are not yet supported, so this remains unused.
+sound_code = """
+// The MIT License
+// Copyright © 2018 Inigo Quilez
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// This shader shows how to use the Common tab in Shadertoy: all tabs inherit the
+// code in the "Common" tab. In this case, that's used to get the Image and the
+// Sound shader to reuse the same music pattern to display the visuals and produce
+// the sound.
+
+
+float tone( in float freq, in float deca, in float time )
+{
+    // fm sound
+    float y = sin(6.2831*freq*time + 5.0*sin(6.2831*freq*time) );
+    // add some harmonics
+    y *= 0.5*(1.0+y*y);
+    // attenaute
+    y *= exp(-(1.0+freq/20.0)*deca);
+    // attack
+    y *= clamp(12.0*deca,0.0,1.0);
+	return y;    
+}
+
+vec2 mainSound( in int samp, float time )
+{
+    // reverb
+    float y = 0.0;
+    float a = 0.7;
+    for( int i=0; i<5; i++ )
+    {       
+        float hime = time - 1.4*float(i)/5.0;
+        float freq = patternFreq( hime );
+        float deca = patternFrac( hime );
+        y += a*tone( freq, deca, hime );
+        a *= 0.6;
+    }
+    
+    return vec2( y );
+}
+"""
+
+
+shader = Shadertoy(image_code, common=common_code, resolution=(800, 450))
 
 if __name__ == "__main__":
     shader.show()

--- a/examples/shadertoy_common.py
+++ b/examples/shadertoy_common.py
@@ -1,0 +1,30 @@
+from wgpu_shadertoy import Shadertoy
+
+# shader_source https://www.shadertoy.com/view/XcSXWD by Vipitis
+
+common_code = """
+// degree of red from 0.0 to 1.0 as a function
+vec3 getRed(float r){
+    return vec3(r, 0.0, 0.0);
+}
+
+// solid green as a variable
+vec3 green = vec3(0.0, 1.0, 0.0);
+"""
+
+shader_code = """
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+    vec2 uv = (fragCoord - .5/iResolution.xy)/iResolution.y;
+
+    vec3 col = getRed(fract(iTime));
+    col += green;
+    // Output to screen
+    fragColor = vec4(col,1.0);
+}
+"""
+
+shader = Shadertoy(shader_code, common=common_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -373,7 +373,7 @@ class Shadertoy:
         )
 
         self._shader_code = shader_code
-        self.common = common
+        self.common = common + "\n"
         self._uniform_data["resolution"] = (*resolution, 1)
 
         self._shader_type = shader_type.lower()

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -321,6 +321,7 @@ class Shadertoy:
 
     Parameters:
         shader_code (str): The shader code to use.
+        common (str): The common shaderpass code gets executed before all other shaderpasses (buffers/image/sound). Defaults to empty string.
         resolution (tuple): The resolution of the shadertoy in (width, height). Defaults to (800, 450).
         shader_type (str): Can be "wgsl" or "glsl". On any other value, it will be automatically detected from shader_code. Default is "auto".
         offscreen (bool): Whether to render offscreen. Default is False.
@@ -354,6 +355,7 @@ class Shadertoy:
     def __init__(
         self,
         shader_code,
+        common="",
         resolution=(800, 450),
         shader_type="auto",
         offscreen=None,
@@ -371,6 +373,7 @@ class Shadertoy:
         )
 
         self._shader_code = shader_code
+        self.common = common
         self._uniform_data["resolution"] = (*resolution, 1)
 
         self._shader_type = shader_type.lower()
@@ -441,12 +444,18 @@ class Shadertoy:
         if shader_type == "glsl":
             vertex_shader_code = vertex_code_glsl
             frag_shader_code = (
-                builtin_variables_glsl + self.shader_code + fragment_code_glsl
+                builtin_variables_glsl
+                + self.common
+                + self.shader_code
+                + fragment_code_glsl
             )
         elif shader_type == "wgsl":
             vertex_shader_code = vertex_code_wgsl
             frag_shader_code = (
-                builtin_variables_wgsl + self.shader_code + fragment_code_wgsl
+                builtin_variables_wgsl
+                + self.common
+                + self.shader_code
+                + fragment_code_wgsl
             )
 
         vertex_shader_program = self._device.create_shader_module(

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -218,14 +218,14 @@ class UniformArray:
     def __init__(self, *args):
         # Analyse incoming fields
         fields = []
-        byte_offet = 0
+        byte_offset = 0
         for name, format, n in args:
             assert format in ("f", "i", "I")
-            field = name, format, byte_offet, byte_offet + n * 4
+            field = name, format, byte_offset, byte_offset + n * 4
             fields.append(field)
-            byte_offet += n * 4
+            byte_offset += n * 4
         # Get padding
-        nbytes = byte_offet
+        nbytes = byte_offset
         while nbytes % 16:
             nbytes += 1
         # Construct memoryview object and a view for each field
@@ -710,7 +710,7 @@ class Shadertoy:
             time_float (float): The time to snapshot. It essentially sets ``i_time`` to a specific number. (Default is 0.0)
             mouse_pos (tuple): The mouse position in pixels in the snapshot. It essentially sets ``i_mouse`` to a 4-tuple. (Default is (0,0,0,0))
         Returns:
-            frame (memoryview): snapshot with transparancy. This object can be converted to a numpy array (without copying data)
+            frame (memoryview): snapshot with transparency. This object can be converted to a numpy array (without copying data)
         using ``np.asarray(arr)``
         """
         if not self._offscreen:


### PR DESCRIPTION
part of #4 (mainly in preparation for adding Buffers A-C, audio shaders and loading form API eventually)

The common tab (sometimes called renderpass by me due to API key-naming) is essentially a shared "library" of functions and variables across the different buffers (including default/image). Information can be found [here](https://shadertoyunofficial.wordpress.com/2016/07/20/special-shadertoy-features/)

The implementation simply puts it between the combability code and the `shader_code` which might not be correct in all cases
So more stuff to check before this is ready:
- [ ] ~~test wgsl~~
- [x] test macros and builtins (according to the blog post)
- [x] better examples