### PR TITLE
Fix shader_type keyword arg

### DIFF
--- a/tests/test_util_shadertoy.py
+++ b/tests/test_util_shadertoy.py
@@ -30,6 +30,31 @@ def test_shadertoy_wgsl():
     shader._draw_frame()
 
 
+def test_shadertoy_wgsl2():
+    # Import here, because it imports the wgpu.gui.auto
+    from wgpu_shadertoy import Shadertoy
+
+    shader_code = """
+        fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+            let uv = frag_coord / i_resolution.xy;
+
+            if ( length(frag_coord - i_mouse.xy) < 20.0 ) {
+                return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            }else{
+                return vec4<f32>( 0.5 + 0.5 * sin(i_time * vec3<f32>(uv, 1.0) ), 1.0);
+            }
+
+        }
+    """
+
+    shader = Shadertoy(shader_code, shader_type="wgsl", resolution=(800, 450))
+    assert shader.resolution == (800, 450)
+    assert shader.shader_code == shader_code
+    assert shader.shader_type == "wgsl"
+
+    shader._draw_frame()
+
+
 def test_shadertoy_glsl():
     # Import here, because it imports the wgpu.gui.auto
     from wgpu_shadertoy import Shadertoy
@@ -72,7 +97,7 @@ def test_shadertoy_glsl2():
         }
     """
 
-    shader = Shadertoy(shader_code, resolution=(800, 450))
+    shader = Shadertoy(shader_code, shader_type="glsl", resolution=(800, 450))
     assert shader.resolution == (800, 450)
     assert shader.shader_code == shader_code
     assert shader.shader_type == "glsl"

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -322,7 +322,7 @@ class Shadertoy:
     Parameters:
         shader_code (str): The shader code to use.
         resolution (tuple): The resolution of the shadertoy in (width, height). Defaults to (800, 450).
-        shader_type (str): Can be "wgsl" or "glsl". If not provided, will be detected automatically.
+        shader_type (str): Can be "wgsl" or "glsl". On any other value, it will be automatically detected from shader_code. Default is "auto".
         offscreen (bool): Whether to render offscreen. Default is False.
         inputs (list): A list of :class:`ShadertoyChannel` objects. Supports up to 4 inputs. Defaults to sampling a black texture.
 

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -402,8 +402,8 @@ class Shadertoy:
     @property
     def shader_type(self):
         """The shader type, automatically detected from the shader code, can be "wgsl" or "glsl"."""
-        if self._shader_code in ("wgsl", "glsl"):
-            return self._shader_code
+        if self._shader_type in ("wgsl", "glsl"):
+            return self._shader_type
 
         wgsl_main_expr = re.compile(r"fn(?:\s)+shader_main")
         glsl_main_expr = re.compile(r"void(?:\s)+(?:shader_main|mainImage)")


### PR DESCRIPTION
We introduced a bug in #21 because we never tested the feature.

this fixes the kwarg actually working and adding tests for both cases.