### PR TITLE
Media caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Special for this repo
 nogit/
 examples/screenshots/diffs
+media/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Special for this repo
 nogit/
 examples/screenshots/diffs
-media/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,6 +48,20 @@ def test_shadertoy_from_id(api_available):
     assert shader.inputs[0].texture_size == (256, 32, 1)
 
 
+def test_shadertoy_from_id_without_cache(api_available):
+    # Import here, because it imports the wgpu.gui.auto
+    from wgpu_shadertoy import Shadertoy
+
+    # shadertoy source: https://www.shadertoy.com/view/l3fXWN by Vipitis
+    shader = Shadertoy.from_id("l3fXWN", use_cache=False)
+
+    assert shader.title == "API test for CI by jakel101"
+    assert shader.shader_type == "glsl"
+    assert shader.shader_code.startswith("//Confirm API working!")
+    assert shader.common.startswith("//Common pass loaded!")
+    assert shader.inputs != []
+
+
 # coverage for shader_args_from_json(dict_or_path, **kwargs)
 def test_from_json_with_invalid_path():
     with pytest.raises(FileNotFoundError):

--- a/wgpu_shadertoy/api.py
+++ b/wgpu_shadertoy/api.py
@@ -124,6 +124,7 @@ def shader_args_from_json(dict_or_path, **kwargs) -> dict:
         shader_data = _load_json(dict_or_path)
     else:
         shader_data = dict_or_path
+    use_cache = kwargs.pop("use_cache", True)
 
     if not isinstance(shader_data, dict):
         raise TypeError("shader_data must be a dict")
@@ -138,7 +139,7 @@ def shader_args_from_json(dict_or_path, **kwargs) -> dict:
         if r_pass["type"] == "image":
             main_image_code = r_pass["code"]
             if r_pass["inputs"] is not []:
-                inputs = _download_media_channels(r_pass["inputs"])
+                inputs = _download_media_channels(r_pass["inputs"], use_cache=use_cache)
         elif r_pass["type"] == "common":
             common_code = r_pass["code"]
         else:


### PR DESCRIPTION
This was mentioned in #25 

Main idea is to avoid downloading the same media (currently just images, maybe additional resources later) over and over again. Should speed things up and avoid duplicate requests.
Media isn't included in the repo, it's build dynamically. The website only offers a quite limited number of default media. Perhaps there could be an init function to grab all of it instead.

This implementation is really crude, as media is cached to a folder in the library, which I don't think is the proper solution. I will look at some other examples.