### PR TITLE
Mark shaders with missing features

### DIFF
--- a/examples/shadertoy_common.py
+++ b/examples/shadertoy_common.py
@@ -131,7 +131,9 @@ vec2 mainSound( in int samp, float time )
 """
 
 
-shader = Shadertoy(image_code, common=common_code, resolution=(800, 450))
+shader = Shadertoy(
+    image_code, common=common_code, resolution=(800, 450), complete=False
+)
 
 if __name__ == "__main__":
     shader.show()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,7 +39,7 @@ def test_shadertoy_from_id(api_available):
     # shadertoy source: https://www.shadertoy.com/view/l3fXWN by Vipitis
     shader = Shadertoy.from_id("l3fXWN")
 
-    assert shader.title == "API test for CI by jakel101"
+    assert shader.title == '"API test for CI" by jakel101'
     assert shader.shader_type == "glsl"
     assert shader.shader_code.startswith("//Confirm API working!")
     assert shader.common.startswith("//Common pass loaded!")
@@ -55,7 +55,7 @@ def test_shadertoy_from_id_without_cache(api_available):
     # shadertoy source: https://www.shadertoy.com/view/l3fXWN by Vipitis
     shader = Shadertoy.from_id("l3fXWN", use_cache=False)
 
-    assert shader.title == "API test for CI by jakel101"
+    assert shader.title == '"API test for CI" by jakel101'
     assert shader.shader_type == "glsl"
     assert shader.shader_code.startswith("//Confirm API working!")
     assert shader.common.startswith("//Common pass loaded!")

--- a/wgpu_shadertoy/api.py
+++ b/wgpu_shadertoy/api.py
@@ -149,7 +149,7 @@ def shader_args_from_json(dict_or_path, **kwargs) -> dict:
         else:
             complete = False
         complete = complete and inputs_complete
-    title = f'{shader_data["Shader"]["info"]["name"]} by {shader_data["Shader"]["info"]["username"]}'
+    title = f'"{shader_data["Shader"]["info"]["name"]}" by {shader_data["Shader"]["info"]["username"]}'
 
     shader_args = {
         "shader_code": main_image_code,

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -274,6 +274,7 @@ class Shadertoy:
         offscreen (bool): Whether to render offscreen. Default is False.
         inputs (list): A list of :class:`ShadertoyChannel` objects. Supports up to 4 inputs. Defaults to sampling a black texture.
         title (str): The title of the window. Defaults to "Shadertoy".
+        complete (bool): Whether the shader is complete. Unsupported renderpasses or inputs will set this to False. Default is True.
 
     The shader code must contain a entry point function:
 
@@ -309,6 +310,7 @@ class Shadertoy:
         offscreen=None,
         inputs=[],
         title: str = "Shadertoy",
+        complete: bool = True,
     ) -> None:
         self._uniform_data = UniformArray(
             ("mouse", "f", 4),
@@ -337,6 +339,10 @@ class Shadertoy:
         self.inputs = inputs
         self.inputs.extend([ShadertoyChannel() for _ in range(4 - len(inputs))])
         self.title = title
+        self.complete = complete
+
+        if not self.complete:
+            self.title += " (incomplete)"
 
         self._prepare_render()
         self._bind_events()


### PR DESCRIPTION
This adds an attribute to the main `Shadertoy` class, to will indicate if any of the currently unsupported features (some texture types, multi pass shaders) are skipped. 

I also need this for a downstream task where I check the whole dataset if shaders work/error/are incomplete.

Should I add some tests?