### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install dev dependencies
       run: |
           python -m pip install --upgrade pip
@@ -41,11 +41,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v5
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install dev dependencies
       run: |
           python -m pip install --upgrade pip twine
@@ -63,11 +63,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
@@ -109,9 +109,9 @@ jobs:
             os: ubuntu-latest
             pyversion: 'pypy3.9'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.pyversion }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.pyversion }}
     - name: Install llvmpipe and lavapipe for offscreen canvas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Test Linux py38
-            os: ubuntu-latest
-            pyversion: '3.8'
           - name: Test Linux py39
             os: ubuntu-latest
             pyversion: '3.9'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: '3.12'
     - name: Install dev dependencies
       run: |
           python -m pip install --upgrade pip
@@ -41,11 +41,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: '3.12'
     - name: Install dev dependencies
       run: |
           python -m pip install --upgrade pip twine

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -12,11 +12,11 @@ jobs:
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
@@ -30,7 +30,7 @@ jobs:
     - name: Regenerate screenshots
       run: |
         pytest -v --regenerate-screenshots -k test_examples_screenshots examples
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: screenshots

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -48,9 +48,11 @@ def test_examples_run(module, force_offscreen):
 def mock_time():
     """Some examples use time to animate. Fix the return value
     for repeatable output."""
-    with patch("time.time") as time_mock, patch(
-        "time.perf_counter"
-    ) as perf_counter_mock, patch("time.localtime") as localtime_mock:
+    with (
+        patch("time.time") as time_mock,
+        patch("time.perf_counter") as perf_counter_mock,
+        patch("time.localtime") as localtime_mock,
+    ):
         time_mock.return_value = 1704449357.71442
         perf_counter_mock.return_value = 6036.9424436
         localtime_mock.return_value = time.struct_time((2024, 1, 5, 11, 9, 25, 4, 5, 0))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 description = "Shadertoy implementation based on wgpu-py"
 license = {file = "LICENSE"}
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 authors = [
   {name = "Jan Kels", email = "Jan.Kels@hhu.de"},
 ]


### PR DESCRIPTION
Bumps the checkout and setup-python actions to their current versions, just like pygfx/wgpu-py#570

Removes Python3.8 (it's EOL in a few days).

I did not touch the publish/release part since I suspect it might need more changes - will look at what was done in `wgpu-py` first