### PR TITLE
Add more uniforms to .snapshot()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+        sudo apt install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
     - name: Install dev dependencies
       run: |
           python -m pip install --upgrade pip
@@ -115,7 +115,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update -y -qq
-        sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+        sudo apt install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
     - name: Install dev dependencies
       run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       env:
         EXPECT_LAVAPIPE: true
       run: |
-          pytest -v examples
+          pytest -vvvs examples
 
   test-builds:
     name: ${{ matrix.name }}
@@ -122,7 +122,7 @@ jobs:
           pip install -e .[dev]
     - name: Unit tests
       run: |
-          pytest -v tests
+          pytest -vvvs tests
 
   publish:
     name: Publish to Github and Pypi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
             pyversion: '3.12'
           - name: Test Linux pypy3
             os: ubuntu-latest
-            pyversion: 'pypy3.9'
+            pyversion: 'pypy3.10'
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.pyversion }}

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get update -y -qq
         sudo add-apt-repository ppa:oibaf/graphics-drivers -y
         sudo apt-get update -y -qq
-        sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+        sudo apt install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -20,8 +20,6 @@ jobs:
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo add-apt-repository ppa:oibaf/graphics-drivers -y
-        sudo apt-get update -y -qq
         sudo apt install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
     - name: Install dev dependencies
       run: |

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -29,7 +29,7 @@ jobs:
         pip install -e .[dev]
     - name: Regenerate screenshots
       run: |
-        pytest -v --regenerate-screenshots -k test_examples_screenshots examples
+        pytest -vvvs --regenerate-screenshots -k test_examples_screenshots examples
     - uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Possible sections in each release:
 
 Added:
 * Run shaders from the website API https://github.com/pygfx/shadertoy/pull/25
+* Additional Uniforms are now supported in `.screenshot()` https://github.com/pygfx/shadertoy/pull/37
 
 ### [v0.1.0] - 2024-01-21
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ To easily load shaders from the website make use of the `.from_id` or `.from_jso
 shader = Shadertoy.from_id("NslGRN")
 ```
 
-When passing `off_screen=True` the `.snapshot()` method allows you to render specific frames.
+When passing `off_screen=True` the `.snapshot()` method allows you to render individual frames with chosen uniforms.
 ```python
 shader = Shadertoy(shader_code, resolution=(800, 450), off_screen=True)
 frame0_data = shader.snapshot()
-frame10_data = shader.snapshot(10.0)
+frame600_data = shader.snapshot(time_float=10.0, frame=600)
 frame0_img = Image.fromarray(np.asarray(frame0_data))
 frame0_img.save("frame0.png")
 ```

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -15,6 +15,7 @@ import pytest
 
 from tests.testutils import (
     ROOT,
+    adapter_summary,
     can_use_wgpu_lib,
     diffs_dir,
     find_examples,
@@ -59,7 +60,7 @@ def mock_time():
 
 
 def test_that_we_are_on_lavapipe():
-    # print(wgpu_backend)
+    print(adapter_summary)
     if os.getenv("EXPECT_LAVAPIPE"):
         assert is_lavapipe
 

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -103,9 +103,9 @@ def test_examples_screenshots(
         imageio.imwrite(screenshot_path, img)
 
     # if a reference screenshot exists, assert it is equal
-    assert (
-        screenshot_path.exists()
-    ), "found # test_example = true but no reference screenshot available"
+    assert screenshot_path.exists(), (
+        "found # test_example = true but no reference screenshot available"
+    )
     stored_img = imageio.imread(screenshot_path)
     # assert similarity
     is_similar = np.allclose(img, stored_img, atol=1)

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -20,7 +20,6 @@ from tests.testutils import (
     find_examples,
     is_lavapipe,
     screenshots_dir,
-    wgpu_backend,
 )
 
 if not can_use_wgpu_lib:
@@ -60,7 +59,7 @@ def mock_time():
 
 
 def test_that_we_are_on_lavapipe():
-    print(wgpu_backend)
+    # print(wgpu_backend)
     if os.getenv("EXPECT_LAVAPIPE"):
         assert is_lavapipe
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -91,15 +91,27 @@ def _determine_can_use_glfw():
     else:
         return True
 
-
+# mix of the changes in https://github.com/pygfx/wgpu-py/pull/604
+# to hopefully avoid the panic?
 def get_default_adapter_summary():
-    """Get description of adapter, or None when no adapter is available."""
-    try:
-        adapter = wgpu.gpu.request_adapter()
-    except RuntimeError:
-        return None  # lib not available, or no adapter on this system
-    return adapter.summary
-
+    """
+    Query the configured wgpu backend driver.
+    """
+    code = "import wgpu; adapter = wgpu.gpu.request_adapter(); print(adapter.summary)"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            code,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        cwd=ROOT,
+    )
+    out = result.stdout.strip()
+    err = result.stderr.strip()
+    return err if "traceback" in err.lower() else out
 
 def find_examples(query=None, negative_query=None, return_stems=False):
     result = []

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -6,8 +6,6 @@ import sys
 from io import StringIO
 from pathlib import Path
 
-import wgpu
-
 ROOT = Path(__file__).parent.parent  # repo root
 examples_dir = ROOT / "examples"
 screenshots_dir = examples_dir / "screenshots"
@@ -91,13 +89,14 @@ def _determine_can_use_glfw():
     else:
         return True
 
+
 # mix of the changes in https://github.com/pygfx/wgpu-py/pull/604
 # to hopefully avoid the panic?
 def get_default_adapter_summary():
     """
     Query the configured wgpu backend driver.
     """
-    code = "import wgpu; adapter = wgpu.gpu.request_adapter(); print(adapter.summary)"
+    code = "import wgpu.utils; adapter = wgpu.utils.get_default_device().adapter; print(adapter.summary)"
     result = subprocess.run(
         [
             sys.executable,
@@ -112,6 +111,7 @@ def get_default_adapter_summary():
     out = result.stdout.strip()
     err = result.stderr.strip()
     return err if "traceback" in err.lower() else out
+
 
 def find_examples(query=None, negative_query=None, return_stems=False):
     result = []

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -73,21 +73,22 @@ def _determine_can_use_wgpu_lib():
         stderr=subprocess.PIPE,
         universal_newlines=True,
     )
-    print("_determine_can_use_wgpu_lib() status code:", result.returncode)
+    print("_determine_can_use_wgpu_lib() result", result)
+
     return (
         result.stdout.strip().endswith("ok")
         and "traceback" not in result.stderr.lower()
     )
 
 
-def _determine_can_use_glfw():
-    code = "import glfw;exit(0) if glfw.init() else exit(1)"
-    try:
-        subprocess.check_output([sys.executable, "-c", code])
-    except Exception:
-        return False
-    else:
-        return True
+# def _determine_can_use_glfw():
+#     code = "import glfw;exit(0) if glfw.init() else exit(1)"
+#     try:
+#         subprocess.check_output([sys.executable, "-c", code])
+#     except Exception:
+#         return False
+#     else:
+#         return True
 
 
 # mix of the changes in https://github.com/pygfx/wgpu-py/pull/604
@@ -130,7 +131,7 @@ def find_examples(query=None, negative_query=None, return_stems=False):
 
 
 can_use_wgpu_lib = _determine_can_use_wgpu_lib()
-can_use_glfw = _determine_can_use_glfw()
+# can_use_glfw = _determine_can_use_glfw()
 is_ci = bool(os.getenv("CI", None))
 is_pypy = sys.implementation.name == "pypy"
 adapter_summary = get_default_adapter_summary()

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -613,7 +613,10 @@ class Shadertoy:
         if not hasattr(self, "_frame"):
             self._frame = 0
 
-        time_struct = time.localtime()
+        current_time = time.time()
+        time_struct = time.localtime(current_time)
+        fractional_seconds = current_time % 1
+        
         self._uniform_data["date"] = (
             float(time_struct.tm_year),
             float(time_struct.tm_mon - 1),
@@ -621,7 +624,7 @@ class Shadertoy:
             time_struct.tm_hour * 3600
             + time_struct.tm_min * 60
             + time_struct.tm_sec
-            + now % 1,
+            + fractional_seconds,
         )
 
         self._uniform_data["frame"] = self._frame


### PR DESCRIPTION
Also fixes #34 by keeping the fractional part.

by skipping the `._update()` method for `offscreen=True` variant we can easily set most of the uniforms in the snapshot method. Should make this very close to deterministic.

note: whole offscreen and snapshot situation needs a rework, as there are recent improvements in wgpu-py that should make it easier. But will look into that at a later date, the current implementation will do.