### PR TITLE
support wgpu v0.18.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "wgpu-shadertoy"
 dynamic = ["version", "readme"]
 dependencies = [
-  "wgpu>=0.16.0,<0.17.0",
+  "wgpu>=0.16.0,<=0.18.1",
   "requests",
   "numpy",
   "Pillow",

--- a/wgpu_shadertoy/api.py
+++ b/wgpu_shadertoy/api.py
@@ -132,7 +132,7 @@ def shader_args_from_json(dict_or_path, **kwargs) -> dict:
     main_image_code = ""
     common_code = ""
     inputs = []
-    complete = True
+    complete = inputs_complete = True
     if "Shader" not in shader_data:
         raise ValueError(
             "shader_data must have a 'Shader' key, following Shadertoy export format."

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -549,18 +549,6 @@ class Shadertoy:
                 "targets": [
                     {
                         "format": wgpu.TextureFormat.bgra8unorm,
-                        "blend": {
-                            "color": (
-                                wgpu.BlendFactor.one,
-                                wgpu.BlendFactor.zero,
-                                wgpu.BlendOperation.add,
-                            ),
-                            "alpha": (
-                                wgpu.BlendFactor.one,
-                                wgpu.BlendFactor.zero,
-                                wgpu.BlendOperation.add,
-                            ),
-                        },
                     },
                 ],
             },


### PR DESCRIPTION
split from #30 

update to support to up `wgpu-py==0.18.1` (by removing the blend argument completely). tested locally with v0.16 and appears to still work.

also fixed small issue with the API script due to an uninitialized variable.