### PR TITLE
Input.py refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Added:
 * Run shaders from the website API https://github.com/pygfx/shadertoy/pull/25
 * Additional Uniforms are now supported in `.screenshot()` https://github.com/pygfx/shadertoy/pull/37
 
+Changed:
+* `ShadertoyChannel` is now more specific `ShadertoyChannelTexture` https://github.com/pygfx/shadertoy/pull/40
+
 ### [v0.1.0] - 2024-01-21
 
 Fixed:

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ if __name__ == "__main__":
     shader.show()
 ```
 
-Texture inputs are supported by using the `ShadertoyChannel` class. Up to 4 channels are supported.
+Texture inputs are supported by using the `ShadertoyChannelTexture` class. Up to 4 channels are supported.
 
 ```python
-from wgpu_shadertoy import Shadertoy, ShadertoyChannel
+from wgpu_shadertoy import Shadertoy, ShadertoyChannelTexture
 from PIL import Image
 
 shader_code = """
@@ -56,7 +56,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 """
 
 img = Image.open("./examples/screenshots/shadertoy_star.png")
-channel0 = ShadertoyChannel(img, wrap="repeat")
+channel0 = ShadertoyChannelTexture(img, wrap="repeat")
 shader = Shadertoy(shader_code, resolution=(800, 450), inputs=[channel0])
 ```
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,9 +43,9 @@ def test_shadertoy_from_id(api_available):
     assert shader.shader_type == "glsl"
     assert shader.shader_code.startswith("//Confirm API working!")
     assert shader.common.startswith("//Common pass loaded!")
-    assert shader.inputs[0].sampler_settings["address_mode_u"] == "clamp-to-edge"
-    assert shader.inputs[0].data.shape == (32, 256, 4)
-    assert shader.inputs[0].texture_size == (256, 32, 1)
+    assert shader.channels[0].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    assert shader.channels[0].data.shape == (32, 256, 4)
+    assert shader.channels[0].texture_size == (256, 32, 1)
 
 
 def test_shadertoy_from_id_without_cache(api_available):
@@ -59,7 +59,7 @@ def test_shadertoy_from_id_without_cache(api_available):
     assert shader.shader_type == "glsl"
     assert shader.shader_code.startswith("//Confirm API working!")
     assert shader.common.startswith("//Common pass loaded!")
-    assert shader.inputs != []
+    assert shader.channels != []
 
 
 # coverage for shader_args_from_json(dict_or_path, **kwargs)

--- a/tests/test_textures.py
+++ b/tests/test_textures.py
@@ -9,7 +9,7 @@ if not can_use_wgpu_lib:
 
 def test_textures_wgsl():
     # Import here, because it imports the wgpu.gui.auto
-    from wgpu_shadertoy import Shadertoy, ShadertoyChannel
+    from wgpu_shadertoy import Shadertoy, ShadertoyChannel, ShadertoyChannelTexture
 
     shader_code_wgsl = """
     fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{
@@ -26,8 +26,9 @@ def test_textures_wgsl():
         bytearray((i for i in range(0, 255, 8) for _ in range(4))) * 32
     ).cast("B", shape=[32, 32, 4])
 
-    channel0 = ShadertoyChannel(test_pattern, wrap="repeat", vflip=False)
-    channel1 = ShadertoyChannel(gradient)
+    # test both construction methods and different sampler settings
+    channel0 = ShadertoyChannelTexture(test_pattern, wrap="repeat", vflip=False)
+    channel1 = ShadertoyChannel(gradient, ctype="texture")
 
     shader = Shadertoy(
         shader_code_wgsl, resolution=(640, 480), inputs=[channel0, channel1]
@@ -35,19 +36,21 @@ def test_textures_wgsl():
     assert shader.resolution == (640, 480)
     assert shader.shader_code == shader_code_wgsl
     assert shader.shader_type == "wgsl"
-    assert shader.inputs[0] == channel0
-    assert np.array_equal(shader.inputs[0].data, test_pattern)
-    assert shader.inputs[0].sampler_settings["address_mode_u"] == "repeat"
-    assert shader.inputs[1] == channel1
-    assert np.array_equal(shader.inputs[1].data, gradient)
-    assert shader.inputs[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    # equivalence only holds true if we use the subclass.
+    assert shader.channels[0] == channel0
+    assert np.array_equal(shader.channels[0].data, test_pattern)
+    assert shader.channels[0].sampler_settings["address_mode_u"] == "repeat"
+    # we can instead make sure the subclass has been correctly inferred
+    assert type(shader.channels[1]) is ShadertoyChannelTexture
+    assert np.array_equal(shader.channels[1].data, gradient)
+    assert shader.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
 
     shader._draw_frame()
 
 
 def test_textures_glsl():
     # Import here, because it imports the wgpu.gui.auto
-    from wgpu_shadertoy import Shadertoy, ShadertoyChannel
+    from wgpu_shadertoy import Shadertoy, ShadertoyChannel, ShadertoyChannelTexture
 
     shader_code = """
     void mainImage( out vec4 fragColor, in vec2 fragCoord )
@@ -66,26 +69,29 @@ def test_textures_glsl():
         bytearray((i for i in range(0, 255, 8) for _ in range(4))) * 32
     ).cast("B", shape=[32, 32, 4])
 
-    channel0 = ShadertoyChannel(test_pattern, wrap="repeat", vflip="false")
-    channel1 = ShadertoyChannel(gradient)
+    # test both construction methods and different sampler settings
+    channel0 = ShadertoyChannelTexture(test_pattern, wrap="repeat", vflip="false")
+    channel1 = ShadertoyChannel(gradient, ctype="texture")
 
     shader = Shadertoy(shader_code, resolution=(640, 480), inputs=[channel0, channel1])
     assert shader.resolution == (640, 480)
     assert shader.shader_code == shader_code
     assert shader.shader_type == "glsl"
-    assert shader.inputs[0] == channel0
-    assert np.array_equal(shader.inputs[0].data, test_pattern)
-    assert shader.inputs[0].sampler_settings["address_mode_u"] == "repeat"
-    assert shader.inputs[1] == channel1
-    assert np.array_equal(shader.inputs[1].data, gradient)
-    assert shader.inputs[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    # equivalence only holds true if we use the subclass.
+    assert shader.channels[0] == channel0
+    assert np.array_equal(shader.channels[0].data, test_pattern)
+    assert shader.channels[0].sampler_settings["address_mode_u"] == "repeat"
+    # we can instead make sure the subclass has been correctly inferred
+    assert type(shader.channels[1]) is ShadertoyChannelTexture
+    assert np.array_equal(shader.channels[1].data, gradient)
+    assert shader.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
 
     shader._draw_frame()
 
 
 def test_channel_res_wgsl():
     # Import here, because it imports the wgpu.gui.auto
-    from wgpu_shadertoy import Shadertoy, ShadertoyChannel
+    from wgpu_shadertoy import Shadertoy, ShadertoyChannel, ShadertoyChannelTexture
 
     shader_code_wgsl = """
     fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{
@@ -106,10 +112,10 @@ def test_channel_res_wgsl():
     }
     """
     img = Image.open("./examples/screenshots/shadertoy_star.png")
-    channel0 = ShadertoyChannel(img.rotate(0, expand=True), wrap="clamp", vflip=True)
-    channel1 = ShadertoyChannel(img.rotate(90, expand=True), wrap="clamp", vflip=False)
-    channel2 = ShadertoyChannel(img.rotate(180, expand=True), wrap="repeat", vflip=True)
-    channel3 = ShadertoyChannel(
+    channel0 = ShadertoyChannelTexture(img.rotate(0, expand=True), wrap="clamp", vflip=True)
+    channel1 = ShadertoyChannelTexture(img.rotate(90, expand=True), wrap="clamp", vflip=False)
+    channel2 = ShadertoyChannelTexture(img.rotate(180, expand=True), wrap="repeat", vflip=True)
+    channel3 = ShadertoyChannelTexture(
         img.rotate(270, expand=True), wrap="repeat", vflip=False
     )
     shader = Shadertoy(
@@ -120,7 +126,7 @@ def test_channel_res_wgsl():
     assert shader.resolution == (1200, 900)
     assert shader.shader_code == shader_code_wgsl
     assert shader.shader_type == "wgsl"
-    assert len(shader.inputs) == 4
+    assert len(shader.channels) == 4
     assert shader._uniform_data["channel_res"] == [
         800.0,
         450.0,
@@ -143,7 +149,7 @@ def test_channel_res_wgsl():
 
 def test_channel_res_glsl():
     # Import here, because it imports the wgpu.gui.auto
-    from wgpu_shadertoy import Shadertoy, ShadertoyChannel
+    from wgpu_shadertoy import Shadertoy, ShadertoyChannel, ShadertoyChannelTexture
 
     shader_code = """
     void mainImage( out vec4 fragColor, in vec2 fragCoord )
@@ -166,10 +172,10 @@ def test_channel_res_glsl():
     }
     """
     img = Image.open("./examples/screenshots/shadertoy_star.png")
-    channel0 = ShadertoyChannel(img.rotate(0, expand=True), wrap="clamp", vflip=True)
-    channel1 = ShadertoyChannel(img.rotate(90, expand=True), wrap="clamp", vflip=False)
-    channel2 = ShadertoyChannel(img.rotate(180, expand=True), wrap="repeat", vflip=True)
-    channel3 = ShadertoyChannel(
+    channel0 = ShadertoyChannelTexture(img.rotate(0, expand=True), wrap="clamp", vflip=True)
+    channel1 = ShadertoyChannelTexture(img.rotate(90, expand=True), wrap="clamp", vflip=False)
+    channel2 = ShadertoyChannelTexture(img.rotate(180, expand=True), wrap="repeat", vflip=True)
+    channel3 = ShadertoyChannelTexture(
         img.rotate(270, expand=True), wrap="repeat", vflip=False
     )
     shader = Shadertoy(
@@ -180,7 +186,7 @@ def test_channel_res_glsl():
     assert shader.resolution == (1200, 900)
     assert shader.shader_code == shader_code
     assert shader.shader_type == "glsl"
-    assert len(shader.inputs) == 4
+    assert len(shader.channels) == 4
     assert shader._uniform_data["channel_res"] == [
         800.0,
         450.0,

--- a/tests/test_textures.py
+++ b/tests/test_textures.py
@@ -91,7 +91,7 @@ def test_textures_glsl():
 
 def test_channel_res_wgsl():
     # Import here, because it imports the wgpu.gui.auto
-    from wgpu_shadertoy import Shadertoy, ShadertoyChannel, ShadertoyChannelTexture
+    from wgpu_shadertoy import Shadertoy, ShadertoyChannelTexture
 
     shader_code_wgsl = """
     fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{
@@ -112,9 +112,15 @@ def test_channel_res_wgsl():
     }
     """
     img = Image.open("./examples/screenshots/shadertoy_star.png")
-    channel0 = ShadertoyChannelTexture(img.rotate(0, expand=True), wrap="clamp", vflip=True)
-    channel1 = ShadertoyChannelTexture(img.rotate(90, expand=True), wrap="clamp", vflip=False)
-    channel2 = ShadertoyChannelTexture(img.rotate(180, expand=True), wrap="repeat", vflip=True)
+    channel0 = ShadertoyChannelTexture(
+        img.rotate(0, expand=True), wrap="clamp", vflip=True
+    )
+    channel1 = ShadertoyChannelTexture(
+        img.rotate(90, expand=True), wrap="clamp", vflip=False
+    )
+    channel2 = ShadertoyChannelTexture(
+        img.rotate(180, expand=True), wrap="repeat", vflip=True
+    )
     channel3 = ShadertoyChannelTexture(
         img.rotate(270, expand=True), wrap="repeat", vflip=False
     )
@@ -149,7 +155,7 @@ def test_channel_res_wgsl():
 
 def test_channel_res_glsl():
     # Import here, because it imports the wgpu.gui.auto
-    from wgpu_shadertoy import Shadertoy, ShadertoyChannel, ShadertoyChannelTexture
+    from wgpu_shadertoy import Shadertoy, ShadertoyChannelTexture
 
     shader_code = """
     void mainImage( out vec4 fragColor, in vec2 fragCoord )
@@ -172,9 +178,15 @@ def test_channel_res_glsl():
     }
     """
     img = Image.open("./examples/screenshots/shadertoy_star.png")
-    channel0 = ShadertoyChannelTexture(img.rotate(0, expand=True), wrap="clamp", vflip=True)
-    channel1 = ShadertoyChannelTexture(img.rotate(90, expand=True), wrap="clamp", vflip=False)
-    channel2 = ShadertoyChannelTexture(img.rotate(180, expand=True), wrap="repeat", vflip=True)
+    channel0 = ShadertoyChannelTexture(
+        img.rotate(0, expand=True), wrap="clamp", vflip=True
+    )
+    channel1 = ShadertoyChannelTexture(
+        img.rotate(90, expand=True), wrap="clamp", vflip=False
+    )
+    channel2 = ShadertoyChannelTexture(
+        img.rotate(180, expand=True), wrap="repeat", vflip=True
+    )
     channel3 = ShadertoyChannelTexture(
         img.rotate(270, expand=True), wrap="repeat", vflip=False
     )

--- a/wgpu_shadertoy/__init__.py
+++ b/wgpu_shadertoy/__init__.py
@@ -1,4 +1,4 @@
-from .inputs import ShadertoyChannel
+from .inputs import ShadertoyChannel, ShadertoyChannelTexture
 from .shadertoy import Shadertoy
 
 __version__ = "0.1.0"

--- a/wgpu_shadertoy/api.py
+++ b/wgpu_shadertoy/api.py
@@ -82,7 +82,7 @@ def _download_media_channels(inputs: list, use_cache=True) -> Tuple[list["Shader
         else:
             complete = False
             continue # skip the below rows
-        channel = ShadertoyChannel(**args, ctype=inp["ctype"], channel_idx=["channel"], **inp["sampler"])
+        channel = ShadertoyChannel(**args, ctype=inp["ctype"], channel_idx=inp["channel"], **inp["sampler"])
         channels[inp["channel"]] = channel
     return channels, complete
 

--- a/wgpu_shadertoy/api.py
+++ b/wgpu_shadertoy/api.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import requests
 from PIL import Image
 
-from .inputs import ShadertoyChannel, ShadertoyChannelTexture
+from .inputs import ShadertoyChannel
 
 HEADERS = {"user-agent": "https://github.com/pygfx/shadertoy script"}
 
@@ -52,7 +52,9 @@ def _get_cache_dir(subdir="media") -> os.PathLike:
     return cache_dir
 
 
-def _download_media_channels(inputs: list, use_cache=True) -> Tuple[list["ShadertoyChannel"], bool]:
+def _download_media_channels(
+    inputs: list, use_cache=True
+) -> Tuple[list["ShadertoyChannel"], bool]:
     """
     Downloads media (currently just textures) from Shadertoy.com and returns a list of `ShadertoyChannel` subclasses to be directly used for `inputs`.
     Requires internet connection (API key not required).
@@ -81,8 +83,10 @@ def _download_media_channels(inputs: list, use_cache=True) -> Tuple[list["Shader
             args = {"data": img}
         else:
             complete = False
-            continue # skip the below rows
-        channel = ShadertoyChannel(**args, ctype=inp["ctype"], channel_idx=inp["channel"], **inp["sampler"])
+            continue  # skip the below rows
+        channel = ShadertoyChannel(
+            **args, ctype=inp["ctype"], channel_idx=inp["channel"], **inp["sampler"]
+        )
         channels[inp["channel"]] = channel
     return channels, complete
 

--- a/wgpu_shadertoy/api.py
+++ b/wgpu_shadertoy/api.py
@@ -1,11 +1,12 @@
 import json
 import os
 import sys
+from typing import Tuple
 
 import requests
 from PIL import Image
 
-from .inputs import ShadertoyChannel
+from .inputs import ShadertoyChannel, ShadertoyChannelTexture
 
 HEADERS = {"user-agent": "https://github.com/pygfx/shadertoy script"}
 
@@ -51,38 +52,39 @@ def _get_cache_dir(subdir="media") -> os.PathLike:
     return cache_dir
 
 
-def _download_media_channels(inputs: list, use_cache=True):
+def _download_media_channels(inputs: list, use_cache=True) -> Tuple[list["ShadertoyChannel"], bool]:
     """
-    Downloads media (currently just textures) from Shadertoy.com and returns a list of `ShadertoyChannel` to be directly used for `inputs`.
+    Downloads media (currently just textures) from Shadertoy.com and returns a list of `ShadertoyChannel` subclasses to be directly used for `inputs`.
     Requires internet connection (API key not required).
     """
     media_url = "https://www.shadertoy.com"
-    channels = {}
+    channels = [None] * 4
     cache_dir = _get_cache_dir("media")
     complete = True
     for inp in inputs:
-        if inp["ctype"] != "texture":
-            complete = False
-            continue  # TODO: support other media types
-
-        cache_path = os.path.join(cache_dir, inp["src"].split("/")[-1])
-        if use_cache and os.path.exists(cache_path):
-            img = Image.open(cache_path)
-        else:
-            response = requests.get(
-                media_url + inp["src"], headers=HEADERS, stream=True
-            )
-            if response.status_code != 200:
-                raise requests.exceptions.HTTPError(
-                    f"Failed to load media {media_url + inp['src']} with status code {response.status_code}"
+        # careful, the order of inputs is not guaranteed to be the same as the order of channels!
+        if inp["ctype"] == "texture":
+            cache_path = os.path.join(cache_dir, inp["src"].split("/")[-1])
+            if use_cache and os.path.exists(cache_path):
+                img = Image.open(cache_path)
+            else:
+                response = requests.get(
+                    media_url + inp["src"], headers=HEADERS, stream=True
                 )
-            img = Image.open(response.raw)
-            if use_cache:
-                img.save(cache_path)
-
-        channel = ShadertoyChannel(img, kind="texture", **inp["sampler"])
+                if response.status_code != 200:
+                    raise requests.exceptions.HTTPError(
+                        f"Failed to load media {media_url + inp['src']} with status code {response.status_code}"
+                    )
+                img = Image.open(response.raw)
+                if use_cache:
+                    img.save(cache_path)
+            args = {"data": img}
+        else:
+            complete = False
+            continue # skip the below rows
+        channel = ShadertoyChannel(**args, ctype=inp["ctype"], channel_idx=["channel"], **inp["sampler"])
         channels[inp["channel"]] = channel
-    return list(channels.values()), complete
+    return channels, complete
 
 
 def _save_json(data, path):

--- a/wgpu_shadertoy/inputs.py
+++ b/wgpu_shadertoy/inputs.py
@@ -234,7 +234,6 @@ class ShadertoyChannelTexture(ShadertoyChannel):
         )
 
         texture_view = texture.create_view()
-        #destination, data, data_layout, size
         device.queue.write_texture(
             destination={
                 "texture": texture,

--- a/wgpu_shadertoy/inputs.py
+++ b/wgpu_shadertoy/inputs.py
@@ -1,68 +1,99 @@
+from typing import Tuple
+
 import numpy as np
+import wgpu
 
 
 class ShadertoyChannel:
     """
-    Represents a shadertoy channel. It can be a texture.
+    ShadertoyChannel Base class. If nothing is provided, it defaults to a 8x8 black texture.
     Parameters:
-        data (array-like): Of shape (width, height, channels), will be converted to numpy array. Default is a 8x8 black texture.
-        kind (str): The kind of channel. Can be one of ("texture"). More will be supported in the future
+        ctype (str): channeltype, can be "texture", "buffer", "video", "webcam", "music", "mic", "keyboard", "cubemap", "volume"; default assumes texture.
+        channel_idx (int): The channel index, can be one of (0, 1, 2, 3). Default is None. It will be set by the parent renderpass.
         **kwargs: Additional arguments for the sampler:
         wrap (str): The wrap mode, can be one of ("clamp-to-edge", "repeat", "clamp"). Default is "clamp-to-edge".
-        vflip (str or bool): Whether to flip the texture vertically. Can be one of ("true", "false", True, False). Default is True.
     """
 
-    # TODO: add cubemap/volume, buffer, webcam, video, audio, keyboard?
+    def __init__(self, *args, ctype=None, channel_idx=None, **kwargs):
+        self.ctype = ctype
+        if channel_idx is not None:
+            channel_idx = kwargs.pop("channel_idx", None)
+        self._channel_idx:int = channel_idx
+        self.args = args
+        self.kwargs = kwargs
+        self.dynamic:bool = False
 
-    def __init__(self, data=None, kind="texture", **kwargs):
-        if kind != "texture":
-            raise NotImplementedError("Only texture is supported for now.")
-        if data is not None:
-            self.data = np.ascontiguousarray(data)
-        else:
-            self.data = np.zeros((8, 8, 4), dtype=np.uint8)
+        @property
+        def sampler_settings(sef) -> dict:
+            """
+            Sampler settings for this channel. Wrap currently supported. Filter not yet.
+            """
+            settings = {}
+            wrap = kwargs.pop("wrap", "clamp-to-edge")
+            # "warp", "clamp" or "repeat" is what we should expect on Shadertoy
+            if wrap.startswith("clamp"):
+                wrap = "clamp-to-edge"
+            settings["address_mode_u"] = wrap
+            settings["address_mode_v"] = wrap
+            # we don't do 3D textures yet, but I guess ssetting this too is fine.
+            settings["address_mode_w"] = wrap
+            return settings
 
-        # if channel dimension is missing, it's a greyscale texture
-        if len(self.data.shape) == 2:
-            self.data = np.reshape(self.data, self.data.shape + (1,))
-        # greyscale textures become just red while green and blue remain 0s
-        if self.data.shape[2] == 1:
-            self.data = np.stack(
-                [
-                    self.data[:, :, 0],
-                    np.zeros_like(self.data[:, :, 0]),
-                    np.zeros_like(self.data[:, :, 0]),
-                ],
-                axis=-1,
-            )
-        # if alpha channel is not given, it's filled with max value (255)
-        if self.data.shape[2] == 3:
-            self.data = np.concatenate(
-                [self.data, np.full(self.data.shape[:2] + (1,), 255, dtype=np.uint8)],
-                axis=2,
-            )
+        @property
+        def parent(self) -> "RenderPass":
+            """
+            Parent renderpass of this channel.
+            """
+            if not hasattr(self, "_parent"):
+                raise AttributeError("Parent not set.")
+            return self._parent
 
-        self.size = self.data.shape  # (rows, columns, channels)
-        self.texture_size = (
-            self.data.shape[1],
-            self.data.shape[0],
-            1,
-        )  # orientation change (columns, rows, 1)
-        self.bytes_per_pixel = (
-            self.data.nbytes // self.data.shape[1] // self.data.shape[0]
-        )
-        vflip = kwargs.pop("vflip", True)
-        if vflip in ("true", True):
-            vflip = True
-            self.data = np.ascontiguousarray(self.data[::-1, :, :])
+        @parent.setter
+        def parent(self, parent):
+            self._parent = parent
 
-        self.sampler_settings = {}
-        wrap = kwargs.pop("wrap", "clamp-to-edge")
-        if wrap.startswith("clamp"):
-            wrap = "clamp-to-edge"
-        self.sampler_settings["address_mode_u"] = wrap
-        self.sampler_settings["address_mode_v"] = wrap
-        self.sampler_settings["address_mode_w"] = wrap
+        @property
+        def channel_idx(self) -> int:
+            if self._channel_idx is None:
+                raise AttributeError("Channel index not set.")
+            return self._channel_idx
+
+        @channel_idx.setter
+        def channel_idx(self, idx=int):
+            if idx not in (0, 1, 2, 3):
+                raise ValueError("Channel index must be in [0,1,2,3]")
+            self._channel_idx = idx
+
+        @property
+        def texture_binding(self) -> int:
+            return (2 * self.channel_idx) + 1
+
+        @property
+        def sampler_binding(self) -> int:
+            return 2 * (self.channel_idx + 1)
+
+        @property
+        def channel_res(self) -> Tuple[int, int, int, int]:
+            """
+            Tuple of (width, height, pixel_aspect=1, padding=-99)
+            """
+            return (self.size[1], self.size[0], 1, -99)
+        
+
+
+        def infer_subclass(self, *args_, **kwargs_):
+            """
+            Returns an instance of the relevant subclass with the provided arguments.
+            """
+            # TODO: automatically infer from the provided data/file/link/name or code.
+            args = self.args + args_
+            kwargs = {**self.kwargs, **kwargs_}
+            if self.ctype is None or not hasattr(self, "ctype"):
+                raise NotImplementedError("Can't dynamically infer the ctype yet")
+            if self.ctype == "texture":
+                return ShadertoyChannelTexture(*args, channel_idx=self._channel_idx, **kwargs)
+            else:
+                raise NotImplementedError(f"Doesn't support {self.ctype=} yet")
 
     def __repr__(self):
         """
@@ -107,10 +138,83 @@ class ShadertoyChannelCubemapA(ShadertoyChannel):
 # other tabs
 class ShadertoyChannelTexture(ShadertoyChannel):
     """
-    Represents a shadertoy texture. It is a subclass of `ShadertoyChannel`.
+    Represents a Shadertoy texture input channel.
+    Parameters:
+        data (array-like): Of shape (width, height, channels), will be converted to numpy array. Default is a 8x8 black texture.
+        **kwargs: Additional arguments for the sampler:
+        wrap (str): The wrap mode, can be one of ("clamp-to-edge", "repeat", "clamp"). Default is "clamp-to-edge".
+        vflip (str or bool): Whether to flip the texture vertically. Can be one of ("true", "false", True, False). Default is True.
     """
+    # TODO: can we inherent the sampler args part of the docstring?
+    def __init__(self, data=None, **kwargs):
+        super().__init__(**kwargs)
+        if data is not None:
+            self.data = np.ascontiguousarray(data)
+        else:
+            self.data = np.zeros((8, 8, 4), dtype=np.uint8)
 
-    pass
+        # if channel dimension is missing, it's a greyscale texture
+        if len(self.data.shape) == 2:
+            self.data = np.reshape(self.data, self.data.shape + (1,))
+        # greyscale textures become just red while green and blue remain 0s
+        if self.data.shape[2] == 1:
+            self.data = np.stack(
+                [
+                    self.data[:, :, 0],
+                    np.zeros_like(self.data[:, :, 0]),
+                    np.zeros_like(self.data[:, :, 0]),
+                ],
+                axis=-1,
+            )
+        # if alpha channel is not given, it's filled with max value (255)
+        if self.data.shape[2] == 3:
+            self.data = np.concatenate(
+                [self.data, np.full(self.data.shape[:2] + (1,), 255, dtype=np.uint8)],
+                axis=2,
+            )
+
+        # orientation change (columns, rows, 1)
+        self.texture_size = (self.data.shape[1], self.data.shape[0], 1)
+
+        vflip = kwargs.pop("vflip", True)
+        if vflip in ("true", True):
+            vflip = True
+            self.data = np.ascontiguousarray(self.data[::-1, :, :])
+
+    def bind_texture(self, device: wgpu.GPUDevice) -> Tuple[list, list]:
+        """
+        prepares the texture and sampler. Returns it's binding layouts and bindgroup layout entries
+        """
+
+        binding_layout = self._binding_layout()
+        texture = device.create_texture(
+            size=self.texture_size,
+            format=wgpu.TextureFormat.rgba8unorm,
+            usage=wgpu.TextureUsage.TEXTURE_BINDING | wgpu.TextureUsage.COPY_DST,
+        )
+
+        texture_view = texture.create_view()
+        #destination, data, data_layout, size
+        device.queue.write_texture(
+            destination={
+                "texture": texture,
+            },
+            data=self.data,
+            data_layout={
+                "bytes_per_row": self.data.strides[0], #multiple of 256
+                "rows_per_image": self.data.size[0], 
+            },
+            size=texture.size,
+        )
+
+        sampler = device.create_sampler(**self.sampler_settings)
+
+        bind_groups_layout_entry = self._bind_groups_layout_entries(
+            texture_view, sampler
+        )
+
+        return binding_layout, bind_groups_layout_entry
+
 
 
 class ShadertoyChannelCubemap(ShadertoyChannel):

--- a/wgpu_shadertoy/inputs.py
+++ b/wgpu_shadertoy/inputs.py
@@ -21,7 +21,7 @@ class ShadertoyChannel:
         self._channel_idx = channel_idx
         self.args = args
         self.kwargs = kwargs
-        self.dynamic:bool = False
+        self.dynamic: bool = False
 
     @property
     def sampler_settings(self) -> dict:
@@ -40,7 +40,7 @@ class ShadertoyChannel:
         return settings
 
     @property
-    def parent(self) -> "RenderPass":
+    def parent(self):
         """
         Parent renderpass of this channel.
         """
@@ -78,9 +78,9 @@ class ShadertoyChannel:
         Tuple of (width, height, pixel_aspect=1, padding=-99)
         """
         return (self.size[1], self.size[0], 1, -99)
-    
+
     @property
-    def size(self) -> Tuple: #what shape tho?
+    def size(self) -> Tuple:  # what shape tho?
         """
         Size of the texture.
         """
@@ -185,6 +185,7 @@ class ShadertoyChannelTexture(ShadertoyChannel):
         wrap (str): The wrap mode, can be one of ("clamp-to-edge", "repeat", "clamp"). Default is "clamp-to-edge".
         vflip (str or bool): Whether to flip the texture vertically. Can be one of ("true", "false", True, False). Default is True.
     """
+
     # TODO: can we inherent the sampler args part of the docstring?
     def __init__(self, data=None, **kwargs):
         super().__init__(**kwargs)
@@ -240,8 +241,8 @@ class ShadertoyChannelTexture(ShadertoyChannel):
             },
             data=self.data,
             data_layout={
-                "bytes_per_row": self.data.strides[0], #multiple of 256
-                "rows_per_image": self.size[0], 
+                "bytes_per_row": self.data.strides[0],  # multiple of 256
+                "rows_per_image": self.size[0],
             },
             size=texture.size,
         )
@@ -253,7 +254,6 @@ class ShadertoyChannelTexture(ShadertoyChannel):
         )
 
         return binding_layout, bind_groups_layout_entry
-
 
 
 class ShadertoyChannelCubemap(ShadertoyChannel):

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -385,6 +385,13 @@ class Shadertoy:
         return cls.from_json(shader_data, **kwargs)
 
     def _attach_inputs(self, inputs: list) -> List[ShadertoyChannel]:
+        """
+        Attach up to four input (channels) to a RenderPass. 
+        Handles cases where input is detected but not provided by falling back a 8x8 black texture.
+        Also skips inputs that aren't used.
+        Returns a list of `ShadertoyChannel` subclass instances to be set as .channels of the renderpass
+        """
+
         if len(inputs) > 4:
             raise ValueError("Only 4 inputs supported")
 
@@ -404,8 +411,10 @@ class Shadertoy:
             if inp_idx not in detected_channels:
                 channel = None
             elif type(inp) is ShadertoyChannel:
+                # case where the base class is provided
                 channel = inp.infer_subclass(parent=self, channel_idx=inp_idx)
             elif isinstance(inp, ShadertoyChannel):
+                # case where a subclass is provided
                 inp.channel_idx = inp_idx
                 inp.parent = self
                 channel = inp
@@ -416,6 +425,7 @@ class Shadertoy:
                 # do we even get here?
                 channel = None
 
+            # TODO: dynamic channels not yet implemented.
             # if channel is not None:
             #     self._input_headers += channel.get_header(shader_type=self.shader_type)
             channels.append(channel)

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -508,10 +508,8 @@ class Shadertoy:
             layout, layout_entry = channel.bind_texture(device=self._device)
             binding_layout.extend(layout)
             bind_groups_layout_entries.extend(layout_entry)
-            channel_res.append(channel.size[1])  # width
-            channel_res.append(channel.size[0])  # height
-            channel_res.append(1)  # always 1 for pixel aspect ratio
-            channel_res.append(-99)  # padding/tests
+            channel_res.extend(channel.channel_res)
+
         self._uniform_data["channel_res"] = tuple(channel_res)
         bind_group_layout = self._device.create_bind_group_layout(
             entries=binding_layout

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -386,7 +386,7 @@ class Shadertoy:
 
     def _attach_inputs(self, inputs: list) -> List[ShadertoyChannel]:
         """
-        Attach up to four input (channels) to a RenderPass. 
+        Attach up to four input (channels) to a RenderPass.
         Handles cases where input is detected but not provided by falling back a 8x8 black texture.
         Also skips inputs that aren't used.
         Returns a list of `ShadertoyChannel` subclass instances to be set as .channels of the renderpass
@@ -401,8 +401,7 @@ class Shadertoy:
 
         channel_pattern = re.compile(r"(?:iChannel|i_channel)(\d+)")
         detected_channels = [
-            int(c)
-            for c in set(channel_pattern.findall(self.common + self.shader_code))
+            int(c) for c in set(channel_pattern.findall(self.common + self.shader_code))
         ]
 
         channels = []


### PR DESCRIPTION
next split from #30 

Mainly moves the `ChannelTexture` into it's subclass and adapts the usage.

I am not sure if the `@property` pattern to the parent renderpass is the best way forward. Since we might not have the renderpass/shadertoy class when initialising the channel object.