### PR TITLE
Passes refactor

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,12 +40,12 @@ def test_shadertoy_from_id(api_available):
     shader = Shadertoy.from_id("l3fXWN")
 
     assert shader.title == '"API test for CI" by jakel101'
-    assert shader.shader_type == "glsl"
-    assert shader.shader_code.startswith("//Confirm API working!")
+    assert shader.image.shader_type == "glsl"
+    assert shader.image.shader_code.startswith("//Confirm API working!")
     assert shader.common.startswith("//Common pass loaded!")
-    assert shader.channels[0].sampler_settings["address_mode_u"] == "clamp-to-edge"
-    assert shader.channels[0].data.shape == (32, 256, 4)
-    assert shader.channels[0].texture_size == (256, 32, 1)
+    assert shader.image.channels[0].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    assert shader.image.channels[0].data.shape == (32, 256, 4)
+    assert shader.image.channels[0].texture_size == (256, 32, 1)
 
 
 def test_shadertoy_from_id_without_cache(api_available):
@@ -56,10 +56,10 @@ def test_shadertoy_from_id_without_cache(api_available):
     shader = Shadertoy.from_id("l3fXWN", use_cache=False)
 
     assert shader.title == '"API test for CI" by jakel101'
-    assert shader.shader_type == "glsl"
-    assert shader.shader_code.startswith("//Confirm API working!")
+    assert shader.image.shader_type == "glsl"
+    assert shader.image.shader_code.startswith("//Confirm API working!")
     assert shader.common.startswith("//Common pass loaded!")
-    assert shader.channels != []
+    assert shader.image.channels != []
 
 
 # coverage for shader_args_from_json(dict_or_path, **kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,7 +43,9 @@ def test_shadertoy_from_id(api_available):
     assert shader.image.shader_type == "glsl"
     assert shader.image.shader_code.startswith("//Confirm API working!")
     assert shader.common.startswith("//Common pass loaded!")
-    assert shader.image.channels[0].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    assert (
+        shader.image.channels[0].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    )
     assert shader.image.channels[0].data.shape == (32, 256, 4)
     assert shader.image.channels[0].texture_size == (256, 32, 1)
 

--- a/tests/test_textures.py
+++ b/tests/test_textures.py
@@ -43,7 +43,9 @@ def test_textures_wgsl():
     # we can instead make sure the subclass has been correctly inferred
     assert type(shader.image.channels[1]) is ShadertoyChannelTexture
     assert np.array_equal(shader.image.channels[1].data, gradient)
-    assert shader.image.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    assert (
+        shader.image.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    )
 
     shader._draw_frame()
 
@@ -84,7 +86,9 @@ def test_textures_glsl():
     # we can instead make sure the subclass has been correctly inferred
     assert type(shader.image.channels[1]) is ShadertoyChannelTexture
     assert np.array_equal(shader.image.channels[1].data, gradient)
-    assert shader.image.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    assert (
+        shader.image.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    )
 
     shader._draw_frame()
 
@@ -134,8 +138,25 @@ def test_channel_res_wgsl():
     assert shader.image.shader_type == "wgsl"
     assert len(shader.image.channels) == 4
     # the attribute is a tuple of ints
-    assert shader.image._channel_res == (800, 450, 1, -99, 450, 800, 1, -99, 800, 450, 1, -99, 450, 800, 1, -99)
-    shader._draw_frame() # this calls draw on all renderpasses (just image here)
+    assert shader.image._channel_res == (
+        800,
+        450,
+        1,
+        -99,
+        450,
+        800,
+        1,
+        -99,
+        800,
+        450,
+        1,
+        -99,
+        450,
+        800,
+        1,
+        -99,
+    )
+    shader._draw_frame()  # this calls draw on all renderpasses (just image here)
     # this is only written after the pass.draw was called
     # the uniform data is a list of floats, from the last pass drawn (image pass in this case)
     assert shader._uniform_data["channel_res"] == [
@@ -205,7 +226,24 @@ def test_channel_res_glsl():
     assert shader.image.shader_type == "glsl"
     assert len(shader.image.channels) == 4
     # the attribute is a tuple of ints
-    assert shader.image._channel_res == (800, 450, 1, -99, 450, 800, 1, -99, 800, 450, 1, -99, 450, 800, 1, -99)    
+    assert shader.image._channel_res == (
+        800,
+        450,
+        1,
+        -99,
+        450,
+        800,
+        1,
+        -99,
+        800,
+        450,
+        1,
+        -99,
+        450,
+        800,
+        1,
+        -99,
+    )
     shader._draw_frame()
     # this is only written after the pass.draw was called
     # the uniform data is a list of floats

--- a/tests/test_textures.py
+++ b/tests/test_textures.py
@@ -34,16 +34,16 @@ def test_textures_wgsl():
         shader_code_wgsl, resolution=(640, 480), inputs=[channel0, channel1]
     )
     assert shader.resolution == (640, 480)
-    assert shader.shader_code == shader_code_wgsl
-    assert shader.shader_type == "wgsl"
+    assert shader.image.shader_code == shader_code_wgsl
+    assert shader.image.shader_type == "wgsl"
     # equivalence only holds true if we use the subclass.
-    assert shader.channels[0] == channel0
-    assert np.array_equal(shader.channels[0].data, test_pattern)
-    assert shader.channels[0].sampler_settings["address_mode_u"] == "repeat"
+    assert shader.image.channels[0] == channel0
+    assert np.array_equal(shader.image.channels[0].data, test_pattern)
+    assert shader.image.channels[0].sampler_settings["address_mode_u"] == "repeat"
     # we can instead make sure the subclass has been correctly inferred
-    assert type(shader.channels[1]) is ShadertoyChannelTexture
-    assert np.array_equal(shader.channels[1].data, gradient)
-    assert shader.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    assert type(shader.image.channels[1]) is ShadertoyChannelTexture
+    assert np.array_equal(shader.image.channels[1].data, gradient)
+    assert shader.image.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
 
     shader._draw_frame()
 
@@ -75,16 +75,16 @@ def test_textures_glsl():
 
     shader = Shadertoy(shader_code, resolution=(640, 480), inputs=[channel0, channel1])
     assert shader.resolution == (640, 480)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "glsl"
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "glsl"
     # equivalence only holds true if we use the subclass.
-    assert shader.channels[0] == channel0
-    assert np.array_equal(shader.channels[0].data, test_pattern)
-    assert shader.channels[0].sampler_settings["address_mode_u"] == "repeat"
+    assert shader.image.channels[0] == channel0
+    assert np.array_equal(shader.image.channels[0].data, test_pattern)
+    assert shader.image.channels[0].sampler_settings["address_mode_u"] == "repeat"
     # we can instead make sure the subclass has been correctly inferred
-    assert type(shader.channels[1]) is ShadertoyChannelTexture
-    assert np.array_equal(shader.channels[1].data, gradient)
-    assert shader.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
+    assert type(shader.image.channels[1]) is ShadertoyChannelTexture
+    assert np.array_equal(shader.image.channels[1].data, gradient)
+    assert shader.image.channels[1].sampler_settings["address_mode_u"] == "clamp-to-edge"
 
     shader._draw_frame()
 
@@ -130,9 +130,14 @@ def test_channel_res_wgsl():
         inputs=[channel0, channel1, channel2, channel3],
     )
     assert shader.resolution == (1200, 900)
-    assert shader.shader_code == shader_code_wgsl
-    assert shader.shader_type == "wgsl"
-    assert len(shader.channels) == 4
+    assert shader.image.shader_code == shader_code_wgsl
+    assert shader.image.shader_type == "wgsl"
+    assert len(shader.image.channels) == 4
+    # the attribute is a tuple of ints
+    assert shader.image._channel_res == (800, 450, 1, -99, 450, 800, 1, -99, 800, 450, 1, -99, 450, 800, 1, -99)
+    shader._draw_frame() # this calls draw on all renderpasses (just image here)
+    # this is only written after the pass.draw was called
+    # the uniform data is a list of floats, from the last pass drawn (image pass in this case)
     assert shader._uniform_data["channel_res"] == [
         800.0,
         450.0,
@@ -196,9 +201,14 @@ def test_channel_res_glsl():
         inputs=[channel0, channel1, channel2, channel3],
     )
     assert shader.resolution == (1200, 900)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "glsl"
-    assert len(shader.channels) == 4
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "glsl"
+    assert len(shader.image.channels) == 4
+    # the attribute is a tuple of ints
+    assert shader.image._channel_res == (800, 450, 1, -99, 450, 800, 1, -99, 800, 450, 1, -99, 450, 800, 1, -99)    
+    shader._draw_frame()
+    # this is only written after the pass.draw was called
+    # the uniform data is a list of floats
     assert shader._uniform_data["channel_res"] == [
         800.0,
         450.0,

--- a/tests/test_util_shadertoy.py
+++ b/tests/test_util_shadertoy.py
@@ -24,8 +24,8 @@ def test_shadertoy_wgsl():
 
     shader = Shadertoy(shader_code, resolution=(800, 450))
     assert shader.resolution == (800, 450)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "wgsl"
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "wgsl"
 
     shader._draw_frame()
 
@@ -49,8 +49,8 @@ def test_shadertoy_wgsl2():
 
     shader = Shadertoy(shader_code, shader_type="wgsl", resolution=(800, 450))
     assert shader.resolution == (800, 450)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "wgsl"
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "wgsl"
 
     shader._draw_frame()
 
@@ -74,8 +74,8 @@ def test_shadertoy_glsl():
 
     shader = Shadertoy(shader_code, resolution=(800, 450))
     assert shader.resolution == (800, 450)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "glsl"
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "glsl"
 
     shader._draw_frame()
 
@@ -99,8 +99,8 @@ def test_shadertoy_glsl2():
 
     shader = Shadertoy(shader_code, shader_type="glsl", resolution=(800, 450))
     assert shader.resolution == (800, 450)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "glsl"
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "glsl"
 
     shader._draw_frame()
 
@@ -124,8 +124,8 @@ def test_shadertoy_glsl3():
 
     shader = Shadertoy(shader_code, resolution=(800, 450))
     assert shader.resolution == (800, 450)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "glsl"
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "glsl"
 
     shader._draw_frame()
 
@@ -149,8 +149,8 @@ def test_shadertoy_offscreen():
 
     shader = Shadertoy(shader_code, resolution=(800, 450), offscreen=True)
     assert shader.resolution == (800, 450)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "glsl"
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "glsl"
     assert shader._offscreen is True
 
 
@@ -210,8 +210,8 @@ def test_shadertoy_snapshot():
     )
 
     assert shader.resolution == (800, 450)
-    assert shader.shader_code == shader_code
-    assert shader.shader_type == "glsl"
+    assert shader.image.shader_code == shader_code
+    assert shader.image.shader_type == "glsl"
     assert shader._offscreen is True
     assert frame1a == frame1b
     assert frame2a == frame2b

--- a/wgpu_shadertoy/__init__.py
+++ b/wgpu_shadertoy/__init__.py
@@ -1,4 +1,5 @@
 from .inputs import ShadertoyChannel, ShadertoyChannelTexture
+from .passes import ImageRenderPass
 from .shadertoy import Shadertoy
 
 __version__ = "0.1.0"

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -1,0 +1,146 @@
+import re
+from typing import List
+
+import numpy as np
+import wgpu
+
+from .inputs import ShadertoyChannel, ShadertoyChannelTexture
+
+class RenderPass:
+    """
+    Base class for renderpass in a Shadertoy.
+    Parameters:
+        main (Shadertoy): the main `Shadertoy` class of which this renderpass is part of. Defaults to None.
+        code (str): Shadercode for this renderpass.
+        shader_type (str): either "wgsl" or "glsl" can also be "auto" - which then gets solved by a regular expression.
+            Defaults to "glsl".
+        inputs (list): A list of :class:`ShadertoyChannel` objects. Each renderpass supports up to 4 inputs which then become .channel attributes.
+            If used but not given, samples a black texture.
+
+    Attributes:
+        channels (list): A list of :class:`ShadertoyChannel` objects.
+        _format (wgpu.TextureFormat): texture format for the render target.
+
+    """
+    def __init__(self, main:None, code: str, shader_type: str = "glsl", inputs: list = []):
+        self._main = main
+        self._shader_code = code
+        self._shader_type = shader_type
+        self._inputs = inputs
+        self.channels = self._attach_inputs(inputs)
+
+        # this is just a default - do we even need it?
+        self._format: wgpu.TextureFormat = wgpu.TextureFormat.bgra8unorm
+
+        self._prepare_render()
+
+    @property
+    def shader_code(self) -> str:
+        """The shader code to use."""
+        return self._shader_code
+
+    @property
+    def shader_type(self) -> str:
+        """The shader type, automatically detected from the shader code, can be "wgsl" or "glsl"."""
+        if self._shader_type in ("wgsl", "glsl"):
+            return self._shader_type
+
+        wgsl_main_expr = re.compile(r"fn(?:\s)+shader_main")
+        glsl_main_expr = re.compile(r"void(?:\s)+(?:shader_main|mainImage)")
+        if wgsl_main_expr.search(self.shader_code):
+            return "wgsl"
+        elif glsl_main_expr.search(self.shader_code):
+            return "glsl"
+        else:
+            raise ValueError(
+                "Could not find valid entry point function in shader code. Unable to determine if it's wgsl or glsl."
+            )
+
+    def _attach_inputs(self, inputs: list) -> List[ShadertoyChannel]:
+        """
+        Attach up to four input (channels) to a RenderPass.
+        Handles cases where input is detected but not provided by falling back a 8x8 black texture.
+        Also skips inputs that aren't used.
+        Returns a list of `ShadertoyChannel` subclass instances to be set as .channels of the renderpass
+        """
+
+        if len(inputs) > 4:
+            raise ValueError("Only 4 inputs supported")
+
+        # fill up with None to always have 4 inputs.
+        if len(inputs) < 4:
+            inputs.extend([None] * (4 - len(inputs)))
+
+        channel_pattern = re.compile(r"(?:iChannel|i_channel)(\d+)")
+        detected_channels = [
+            int(c) for c in set(channel_pattern.findall(self.common + self.shader_code))
+        ]
+
+        channels = []
+
+        for inp_idx, inp in enumerate(inputs):
+            if inp_idx not in detected_channels:
+                channel = None
+            elif type(inp) is ShadertoyChannel:
+                # case where the base class is provided
+                channel = inp.infer_subclass(parent=self, channel_idx=inp_idx)
+            elif isinstance(inp, ShadertoyChannel):
+                # case where a subclass is provided
+                inp.channel_idx = inp_idx
+                inp.parent = self
+                channel = inp
+            elif inp is None and inp_idx in detected_channels:
+                # this is the base case where we sample the black texture.
+                channel = ShadertoyChannelTexture(channel_idx=inp_idx)
+            else:
+                # do we even get here?
+                channel = None
+
+            # TODO: dynamic channels not yet implemented.
+            # if channel is not None:
+            #     self._input_headers += channel.get_header(shader_type=self.shader_type)
+            channels.append(channel)
+
+        return channels
+
+    def _prepare_render(self):
+        """
+        Should be part of __init__ ?
+        """
+        pass
+
+
+class ImageRenderPass(RenderPass):
+    """
+    The Image RenderPass of a Shadertoy. Renders to a canvas.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class BufferRenderPass(RenderPass):
+    """
+    The Buffer A-D RenderPass of a Shadertoy. Render to a texture that can be used as input for other renderpasses (include itself).
+    Parameters:
+        buffer_idx (str): one of "A", "B", "C" or "D". Required.
+    """
+
+    pass  # TODO at a later date
+
+
+class CubemapRenderPass(RenderPass):
+    """
+    The Cube A RenderPass of a Shadertoy.
+    this has slightly different headers see: https://shadertoyunofficial.wordpress.com/2016/07/20/special-shadertoy-features/
+    """
+
+    pass  # TODO at a later date
+
+
+class SoundRenderPass(RenderPass):
+    """
+    The Sound RenderPass of a Shadertoy.
+    sound is rendered to a buffer at the start and then played back. There is no interactivity....
+    """
+
+    pass  # TODO at a later date

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -6,6 +6,206 @@ import wgpu
 
 from .inputs import ShadertoyChannel, ShadertoyChannelTexture
 
+
+# TODO: simplify all the shader code snippets
+vertex_code_glsl = """#version 450 core
+
+layout(location = 0) out vec2 vert_uv;
+
+void main(void){
+    int index = int(gl_VertexID);
+    if (index == 0) {
+        gl_Position = vec4(-1.0, -1.0, 0.0, 1.0);
+        vert_uv = vec2(0.0, 1.0);
+    } else if (index == 1) {
+        gl_Position = vec4(3.0, -1.0, 0.0, 1.0);
+        vert_uv = vec2(2.0, 1.0);
+    } else {
+        gl_Position = vec4(-1.0, 3.0, 0.0, 1.0);
+        vert_uv = vec2(0.0, -1.0);
+    }
+}
+"""
+
+
+builtin_variables_glsl = """#version 450 core
+
+vec4 i_mouse;
+vec4 i_date;
+vec3 i_resolution;
+float i_time;
+vec3 i_channel_resolution[4];
+float i_time_delta;
+int i_frame;
+float i_framerate;
+
+layout(binding = 1) uniform texture2D i_channel0;
+layout(binding = 2) uniform sampler sampler0;
+layout(binding = 3) uniform texture2D i_channel1;
+layout(binding = 4) uniform sampler sampler1;
+layout(binding = 5) uniform texture2D i_channel2;
+layout(binding = 6) uniform sampler sampler2;
+layout(binding = 7) uniform texture2D i_channel3;
+layout(binding = 8) uniform sampler sampler3;
+
+// Shadertoy compatibility, see we can use the same code copied from shadertoy website
+
+#define iChannel0 sampler2D(i_channel0, sampler0)
+#define iChannel1 sampler2D(i_channel1, sampler1)
+#define iChannel2 sampler2D(i_channel2, sampler2)
+#define iChannel3 sampler2D(i_channel3, sampler3)
+
+#define iMouse i_mouse
+#define iDate i_date
+#define iResolution i_resolution
+#define iTime i_time
+#define iChannelResolution i_channel_resolution
+#define iTimeDelta i_time_delta
+#define iFrame i_frame
+#define iFrameRate i_framerate
+
+#define mainImage shader_main
+"""
+
+
+fragment_code_glsl = """
+layout(location = 0) in vec2 vert_uv;
+
+struct ShadertoyInput {
+    vec4 si_mouse;
+    vec4 si_date;
+    vec3 si_resolution;
+    float si_time;
+    vec3 si_channel_res[4];
+    float si_time_delta;
+    int si_frame;
+    float si_framerate;
+};
+
+layout(binding = 0) uniform ShadertoyInput input;
+out vec4 FragColor;
+void main(){
+
+    i_mouse = input.si_mouse;
+    i_date = input.si_date;
+    i_resolution = input.si_resolution;
+    i_time = input.si_time;
+    i_channel_resolution = input.si_channel_res;
+    i_time_delta = input.si_time_delta;
+    i_frame = input.si_frame;
+    i_framerate = input.si_framerate;
+    vec2 frag_uv = vec2(vert_uv.x, 1.0 - vert_uv.y);
+    vec2 frag_coord = frag_uv * i_resolution.xy;
+
+    shader_main(FragColor, frag_coord);
+
+}
+
+"""
+
+
+vertex_code_wgsl = """
+
+struct Varyings {
+    @builtin(position) position : vec4<f32>,
+    @location(0) vert_uv : vec2<f32>,
+};
+
+@vertex
+fn main(@builtin(vertex_index) index: u32) -> Varyings {
+    var out: Varyings;
+    if (index == u32(0)) {
+        out.position = vec4<f32>(-1.0, -1.0, 0.0, 1.0);
+        out.vert_uv = vec2<f32>(0.0, 1.0);
+    } else if (index == u32(1)) {
+        out.position = vec4<f32>(3.0, -1.0, 0.0, 1.0);
+        out.vert_uv = vec2<f32>(2.0, 1.0);
+    } else {
+        out.position = vec4<f32>(-1.0, 3.0, 0.0, 1.0);
+        out.vert_uv = vec2<f32>(0.0, -1.0);
+    }
+    return out;
+
+}
+"""
+
+
+builtin_variables_wgsl = """
+
+var<private> i_mouse: vec4<f32>;
+var<private> i_date: vec4<f32>;
+var<private> i_resolution: vec3<f32>;
+var<private> i_time: f32;
+var<private> i_channel_resolution: array<vec4<f32>,4>;
+var<private> i_time_delta: f32;
+var<private> i_frame: u32;
+var<private> i_framerate: f32;
+
+// TODO: more global variables
+// var<private> i_frag_coord: vec2<f32>;
+
+"""
+
+
+fragment_code_wgsl = """
+
+struct ShadertoyInput {
+    si_mouse: vec4<f32>,
+    si_date: vec4<f32>,
+    si_resolution: vec3<f32>,
+    si_time: f32,
+    si_channel_res: array<vec4<f32>,4>,
+    si_time_delta: f32,
+    si_frame: u32,
+    si_framerate: f32,
+};
+
+struct Varyings {
+    @builtin(position) position : vec4<f32>,
+    @location(0) vert_uv : vec2<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> input: ShadertoyInput;
+
+@group(0) @binding(1)
+var i_channel0: texture_2d<f32>;
+@group(0) @binding(3)
+var i_channel1: texture_2d<f32>;
+@group(0) @binding(5)
+var i_channel2: texture_2d<f32>;
+@group(0) @binding(7)
+var i_channel3: texture_2d<f32>;
+
+@group(0) @binding(2)
+var sampler0: sampler;
+@group(0) @binding(4)
+var sampler1: sampler;
+@group(0) @binding(6)
+var sampler2: sampler;
+@group(0) @binding(8)
+var sampler3: sampler;
+
+@fragment
+fn main(in: Varyings) -> @location(0) vec4<f32> {
+
+    i_mouse = input.si_mouse;
+    i_date = input.si_date;
+    i_resolution = input.si_resolution;
+    i_time = input.si_time;
+    i_channel_resolution = input.si_channel_res;
+    i_time_delta = input.si_time_delta;
+    i_frame = input.si_frame;
+    i_framerate = input.si_framerate;
+    let frag_uv = vec2<f32>(in.vert_uv.x, 1.0 - in.vert_uv.y);
+    let frag_coord = frag_uv * i_resolution.xy;
+
+    return shader_main(frag_coord);
+}
+
+"""
+
+
 class RenderPass:
     """
     Base class for renderpass in a Shadertoy.
@@ -38,6 +238,17 @@ class RenderPass:
     def shader_code(self) -> str:
         """The shader code to use."""
         return self._shader_code
+
+    @property
+    def main(self) -> "Shadertoy":
+        if self._main is not None:
+            return self._main
+        else:
+            raise AttributeError("_main not set yet")
+
+    @property
+    def _device(self) -> wgpu.GPUDevice:
+        return self.main._device
 
     @property
     def shader_type(self) -> str:
@@ -73,7 +284,7 @@ class RenderPass:
 
         channel_pattern = re.compile(r"(?:iChannel|i_channel)(\d+)")
         detected_channels = [
-            int(c) for c in set(channel_pattern.findall(self.common + self.shader_code))
+            int(c) for c in set(channel_pattern.findall(self.main.common + self.shader_code))
         ]
 
         channels = []
@@ -104,11 +315,125 @@ class RenderPass:
         return channels
 
     def _prepare_render(self):
-        """
-        Should be part of __init__ ?
-        """
-        pass
+        shader_type = self.shader_type
+        if shader_type == "glsl":
+            vertex_shader_code = vertex_code_glsl
+            frag_shader_code = (
+                builtin_variables_glsl
+                + self.main.common
+                + self.shader_code
+                + fragment_code_glsl
+            )
+        elif shader_type == "wgsl":
+            vertex_shader_code = vertex_code_wgsl
+            frag_shader_code = (
+                builtin_variables_wgsl
+                + self.main.common
+                + self.shader_code
+                + fragment_code_wgsl
+            )
 
+        vertex_shader_program = self._device.create_shader_module(
+            label="triangle_vert", code=vertex_shader_code
+        )
+        frag_shader_program = self._device.create_shader_module(
+            label="triangle_frag", code=frag_shader_code
+        )
+
+        self.main._uniform_buffer = self._device.create_buffer(
+            size=self.main._uniform_data.nbytes,
+            usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST,
+        )
+
+        bind_groups_layout_entries = [
+            {
+                "binding": 0,
+                "resource": {
+                    "buffer": self.main._uniform_buffer,
+                    "offset": 0,
+                    "size": self.main._uniform_data.nbytes,
+                },
+            },
+        ]
+
+        binding_layout = [
+            {
+                "binding": 0,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "buffer": {"type": wgpu.BufferBindingType.uniform},
+            },
+        ]
+        channel_res = []
+        for input_idx, channel in enumerate(self.channels):
+            if channel is None:
+                channel_res.extend([0, 0, 1, -99])  # default values; quick hack
+                continue
+            layout, layout_entry = channel.bind_texture(device=self._device)
+            binding_layout.extend(layout)
+            bind_groups_layout_entries.extend(layout_entry)
+            channel_res.extend(channel.channel_res)
+
+        # this uniform data should be per renderpass
+        self.main._uniform_data["channel_res"] = tuple(channel_res)
+        bind_group_layout = self._device.create_bind_group_layout(
+            entries=binding_layout
+        )
+
+        self._bind_group = self._device.create_bind_group(
+            layout=bind_group_layout,
+            entries=bind_groups_layout_entries,
+        )
+
+        self._render_pipeline = self._device.create_render_pipeline(
+            layout=self._device.create_pipeline_layout(
+                bind_group_layouts=[bind_group_layout]
+            ),
+            vertex={
+                "module": vertex_shader_program,
+                "entry_point": "main",
+                "buffers": [],
+            },
+            primitive={
+                "topology": wgpu.PrimitiveTopology.triangle_list,
+                "front_face": wgpu.FrontFace.ccw,
+                "cull_mode": wgpu.CullMode.none,
+            },
+            depth_stencil=None,
+            multisample=None,
+            fragment={
+                "module": frag_shader_program,
+                "entry_point": "main",
+                "targets": [
+                    {
+                        "format": wgpu.TextureFormat.bgra8unorm,
+                    },
+                ],
+            },
+        )
+
+    # can this be generalized?
+    def draw(self) -> wgpu.GPUCommandBuffer:
+        command_encoder = self._device.create_command_encoder()
+        current_texture = self.get_current_texture()
+
+        render_pass = command_encoder.begin_render_pass(
+            color_attachments=[
+                {
+                    "view": current_texture.create_view(),
+                    "resolve_target": None,
+                    "clear_value": (0, 0, 0, 1),
+                    "load_op": wgpu.LoadOp.clear,
+                    "store_op": wgpu.StoreOp.store,
+                }
+            ],
+        )
+
+        render_pass.set_pipeline(self._render_pipeline)
+        render_pass.set_bind_group(0, self._bind_group, [], 0, 99)
+        render_pass.draw(3, 1, 0, 0)
+        render_pass.end()
+
+        return command_encoder.finish()
 
 class ImageRenderPass(RenderPass):
     """
@@ -117,6 +442,12 @@ class ImageRenderPass(RenderPass):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+    def get_current_texture(self) -> wgpu.GPUTexture:
+        """
+        The current (next) texture to draw to
+        """
+        # for the image pass this swap chain is handled by the context/canvas
+        return self.main._present_context.get_current_texture()
 
 class BufferRenderPass(RenderPass):
     """

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -1,7 +1,6 @@
 import re
 from typing import List
 
-import numpy as np
 import wgpu
 
 from .inputs import ShadertoyChannel, ShadertoyChannelTexture
@@ -216,7 +215,10 @@ class RenderPass:
         inputs (list): A list of :class:`ShadertoyChannel` objects. Each renderpass supports up to 4 inputs which then become .channel attributes.
             If used but not given, samples a black texture.
     """
-    def __init__(self, main:None, code: str, shader_type: str = "glsl", inputs: list = []):
+
+    def __init__(
+        self, main: None, code: str, shader_type: str = "glsl", inputs: list = []
+    ):
         self._main = main
         self._shader_code = code
         self._shader_type = shader_type
@@ -234,7 +236,7 @@ class RenderPass:
         return self._shader_code
 
     @property
-    def main(self) -> "Shadertoy":
+    def main(self):  # -> "Shadertoy": #TODO: how can be get this type hint?
         if self._main is not None:
             return self._main
         else:
@@ -278,7 +280,8 @@ class RenderPass:
 
         channel_pattern = re.compile(r"(?:iChannel|i_channel)(\d+)")
         detected_channels = [
-            int(c) for c in set(channel_pattern.findall(self.main.common + self.shader_code))
+            int(c)
+            for c in set(channel_pattern.findall(self.main.common + self.shader_code))
         ]
 
         channels = []
@@ -428,10 +431,10 @@ class RenderPass:
             size=self.main._uniform_data.nbytes,
         )
 
-        command_encoder:wgpu.GPUCommandEncoder = self._device.create_command_encoder()
-        current_texture:wgpu.GPUTexture = self.get_current_texture()
+        command_encoder: wgpu.GPUCommandEncoder = self._device.create_command_encoder()
+        current_texture: wgpu.GPUTexture = self.get_current_texture()
 
-        render_pass:wgpu.GPURenderPassEncoder = command_encoder.begin_render_pass(
+        render_pass: wgpu.GPURenderPassEncoder = command_encoder.begin_render_pass(
             color_attachments=[
                 {
                     "view": current_texture.create_view(),
@@ -451,10 +454,12 @@ class RenderPass:
 
         return command_encoder.finish()
 
+
 class ImageRenderPass(RenderPass):
     """
     The Image RenderPass of a Shadertoy. Renders to a canvas.
     """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -464,6 +469,7 @@ class ImageRenderPass(RenderPass):
         """
         # for the image pass this swap chain is handled by the context/canvas
         return self.main._present_context.get_current_texture()
+
 
 class BufferRenderPass(RenderPass):
     """

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -263,20 +263,18 @@ class RenderPass:
     @property
     def shader_type(self) -> str:
         """The shader type, automatically detected from the shader code, can be "wgsl" or "glsl"."""
-        if self._shader_type in ("wgsl", "glsl"):
-            return self._shader_type
-
-        wgsl_main_expr = re.compile(r"fn(?:\s)+shader_main")
-        glsl_main_expr = re.compile(r"void(?:\s)+(?:shader_main|mainImage)")
-        if wgsl_main_expr.search(self.shader_code):
-            # TODO: this should also set the ._shader_type attribute.
-            return "wgsl"
-        elif glsl_main_expr.search(self.shader_code):
-            return "glsl"
-        else:
-            raise ValueError(
-                "Could not find valid entry point function in shader code. Unable to determine if it's wgsl or glsl."
-            )
+        if self._shader_type not in ("wgsl", "glsl"):
+            wgsl_main_expr = re.compile(r"fn(?:\s)+shader_main")
+            glsl_main_expr = re.compile(r"void(?:\s)+(?:shader_main|mainImage)")
+            if wgsl_main_expr.search(self.shader_code):
+                self._shader_type = "wgsl"
+            elif glsl_main_expr.search(self.shader_code):
+                self._shader_type = "glsl"
+            else:
+                raise ValueError(
+                    "Could not find valid entry point function in shader code. Unable to determine if it's wgsl or glsl."
+                )
+        return self._shader_type
 
     def _attach_inputs(self, inputs: list) -> List[ShadertoyChannel]:
         """

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -11,205 +11,8 @@ from wgpu.gui.offscreen import WgpuCanvas as OffscreenCanvas
 from wgpu.gui.offscreen import run as run_offscreen
 
 from .api import shader_args_from_json, shadertoy_from_id
+from .passes import ImageRenderPass
 from .inputs import ShadertoyChannel, ShadertoyChannelTexture
-
-vertex_code_glsl = """#version 450 core
-
-layout(location = 0) out vec2 vert_uv;
-
-void main(void){
-    int index = int(gl_VertexID);
-    if (index == 0) {
-        gl_Position = vec4(-1.0, -1.0, 0.0, 1.0);
-        vert_uv = vec2(0.0, 1.0);
-    } else if (index == 1) {
-        gl_Position = vec4(3.0, -1.0, 0.0, 1.0);
-        vert_uv = vec2(2.0, 1.0);
-    } else {
-        gl_Position = vec4(-1.0, 3.0, 0.0, 1.0);
-        vert_uv = vec2(0.0, -1.0);
-    }
-}
-"""
-
-
-builtin_variables_glsl = """#version 450 core
-
-vec4 i_mouse;
-vec4 i_date;
-vec3 i_resolution;
-float i_time;
-vec3 i_channel_resolution[4];
-float i_time_delta;
-int i_frame;
-float i_framerate;
-
-layout(binding = 1) uniform texture2D i_channel0;
-layout(binding = 2) uniform sampler sampler0;
-layout(binding = 3) uniform texture2D i_channel1;
-layout(binding = 4) uniform sampler sampler1;
-layout(binding = 5) uniform texture2D i_channel2;
-layout(binding = 6) uniform sampler sampler2;
-layout(binding = 7) uniform texture2D i_channel3;
-layout(binding = 8) uniform sampler sampler3;
-
-// Shadertoy compatibility, see we can use the same code copied from shadertoy website
-
-#define iChannel0 sampler2D(i_channel0, sampler0)
-#define iChannel1 sampler2D(i_channel1, sampler1)
-#define iChannel2 sampler2D(i_channel2, sampler2)
-#define iChannel3 sampler2D(i_channel3, sampler3)
-
-#define iMouse i_mouse
-#define iDate i_date
-#define iResolution i_resolution
-#define iTime i_time
-#define iChannelResolution i_channel_resolution
-#define iTimeDelta i_time_delta
-#define iFrame i_frame
-#define iFrameRate i_framerate
-
-#define mainImage shader_main
-"""
-
-
-fragment_code_glsl = """
-layout(location = 0) in vec2 vert_uv;
-
-struct ShadertoyInput {
-    vec4 si_mouse;
-    vec4 si_date;
-    vec3 si_resolution;
-    float si_time;
-    vec3 si_channel_res[4];
-    float si_time_delta;
-    int si_frame;
-    float si_framerate;
-};
-
-layout(binding = 0) uniform ShadertoyInput input;
-out vec4 FragColor;
-void main(){
-
-    i_mouse = input.si_mouse;
-    i_date = input.si_date;
-    i_resolution = input.si_resolution;
-    i_time = input.si_time;
-    i_channel_resolution = input.si_channel_res;
-    i_time_delta = input.si_time_delta;
-    i_frame = input.si_frame;
-    i_framerate = input.si_framerate;
-    vec2 frag_uv = vec2(vert_uv.x, 1.0 - vert_uv.y);
-    vec2 frag_coord = frag_uv * i_resolution.xy;
-
-    shader_main(FragColor, frag_coord);
-
-}
-
-"""
-
-
-vertex_code_wgsl = """
-
-struct Varyings {
-    @builtin(position) position : vec4<f32>,
-    @location(0) vert_uv : vec2<f32>,
-};
-
-@vertex
-fn main(@builtin(vertex_index) index: u32) -> Varyings {
-    var out: Varyings;
-    if (index == u32(0)) {
-        out.position = vec4<f32>(-1.0, -1.0, 0.0, 1.0);
-        out.vert_uv = vec2<f32>(0.0, 1.0);
-    } else if (index == u32(1)) {
-        out.position = vec4<f32>(3.0, -1.0, 0.0, 1.0);
-        out.vert_uv = vec2<f32>(2.0, 1.0);
-    } else {
-        out.position = vec4<f32>(-1.0, 3.0, 0.0, 1.0);
-        out.vert_uv = vec2<f32>(0.0, -1.0);
-    }
-    return out;
-
-}
-"""
-
-
-builtin_variables_wgsl = """
-
-var<private> i_mouse: vec4<f32>;
-var<private> i_date: vec4<f32>;
-var<private> i_resolution: vec3<f32>;
-var<private> i_time: f32;
-var<private> i_channel_resolution: array<vec4<f32>,4>;
-var<private> i_time_delta: f32;
-var<private> i_frame: u32;
-var<private> i_framerate: f32;
-
-// TODO: more global variables
-// var<private> i_frag_coord: vec2<f32>;
-
-"""
-
-
-fragment_code_wgsl = """
-
-struct ShadertoyInput {
-    si_mouse: vec4<f32>,
-    si_date: vec4<f32>,
-    si_resolution: vec3<f32>,
-    si_time: f32,
-    si_channel_res: array<vec4<f32>,4>,
-    si_time_delta: f32,
-    si_frame: u32,
-    si_framerate: f32,
-};
-
-struct Varyings {
-    @builtin(position) position : vec4<f32>,
-    @location(0) vert_uv : vec2<f32>,
-};
-
-@group(0) @binding(0)
-var<uniform> input: ShadertoyInput;
-
-@group(0) @binding(1)
-var i_channel0: texture_2d<f32>;
-@group(0) @binding(3)
-var i_channel1: texture_2d<f32>;
-@group(0) @binding(5)
-var i_channel2: texture_2d<f32>;
-@group(0) @binding(7)
-var i_channel3: texture_2d<f32>;
-
-@group(0) @binding(2)
-var sampler0: sampler;
-@group(0) @binding(4)
-var sampler1: sampler;
-@group(0) @binding(6)
-var sampler2: sampler;
-@group(0) @binding(8)
-var sampler3: sampler;
-
-@fragment
-fn main(in: Varyings) -> @location(0) vec4<f32> {
-
-    i_mouse = input.si_mouse;
-    i_date = input.si_date;
-    i_resolution = input.si_resolution;
-    i_time = input.si_time;
-    i_channel_resolution = input.si_channel_res;
-    i_time_delta = input.si_time_delta;
-    i_frame = input.si_frame;
-    i_framerate = input.si_framerate;
-    let frag_uv = vec2<f32>(in.vert_uv.x, 1.0 - in.vert_uv.y);
-    let frag_coord = frag_uv * i_resolution.xy;
-
-    return shader_main(frag_coord);
-}
-
-"""
-
 
 class UniformArray:
     """Convenience class to create a uniform array.
@@ -335,15 +138,18 @@ class Shadertoy:
             offscreen = True
         self._offscreen = offscreen
 
-        self.channels = self._attach_inputs(inputs)
+        # self.channels = self._attach_inputs(inputs)
         self.title = title
         self.complete = complete
 
         if not self.complete:
             self.title += " (incomplete)"
 
-        self._prepare_render()
+        self._prepare_canvas()
         self._bind_events()
+
+        # setting up the renderpasses, inputs to the main class get handed to the .image pass
+        self.image = ImageRenderPass(main=self, code=shader_code, shader_type=shader_type, inputs=inputs)
 
     @property
     def resolution(self):
@@ -362,7 +168,7 @@ class Shadertoy:
         shader_data = shadertoy_from_id(id_or_url)
         return cls.from_json(shader_data, **kwargs)
 
-    def _prepare_render(self):
+    def _prepare_canvas(self):
         import wgpu.backends.auto
 
         if self._offscreen:
@@ -381,101 +187,6 @@ class Shadertoy:
         # We use "bgra8unorm" not "bgra8unorm-srgb" here because we want to let the shader fully control the color-space.
         self._present_context.configure(
             device=self._device, format=wgpu.TextureFormat.bgra8unorm
-        )
-
-        shader_type = self.shader_type
-        if shader_type == "glsl":
-            vertex_shader_code = vertex_code_glsl
-            frag_shader_code = (
-                builtin_variables_glsl
-                + self.common
-                + self.shader_code
-                + fragment_code_glsl
-            )
-        elif shader_type == "wgsl":
-            vertex_shader_code = vertex_code_wgsl
-            frag_shader_code = (
-                builtin_variables_wgsl
-                + self.common
-                + self.shader_code
-                + fragment_code_wgsl
-            )
-
-        vertex_shader_program = self._device.create_shader_module(
-            label="triangle_vert", code=vertex_shader_code
-        )
-        frag_shader_program = self._device.create_shader_module(
-            label="triangle_frag", code=frag_shader_code
-        )
-
-        self._uniform_buffer = self._device.create_buffer(
-            size=self._uniform_data.nbytes,
-            usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST,
-        )
-
-        bind_groups_layout_entries = [
-            {
-                "binding": 0,
-                "resource": {
-                    "buffer": self._uniform_buffer,
-                    "offset": 0,
-                    "size": self._uniform_data.nbytes,
-                },
-            },
-        ]
-
-        binding_layout = [
-            {
-                "binding": 0,
-                "visibility": wgpu.ShaderStage.FRAGMENT,
-                "buffer": {"type": wgpu.BufferBindingType.uniform},
-            },
-        ]
-        channel_res = []
-        for input_idx, channel in enumerate(self.channels):
-            if channel is None:
-                channel_res.extend([0, 0, 1, -99])  # default values; quick hack
-                continue
-            layout, layout_entry = channel.bind_texture(device=self._device)
-            binding_layout.extend(layout)
-            bind_groups_layout_entries.extend(layout_entry)
-            channel_res.extend(channel.channel_res)
-
-        self._uniform_data["channel_res"] = tuple(channel_res)
-        bind_group_layout = self._device.create_bind_group_layout(
-            entries=binding_layout
-        )
-
-        self._bind_group = self._device.create_bind_group(
-            layout=bind_group_layout,
-            entries=bind_groups_layout_entries,
-        )
-
-        self._render_pipeline = self._device.create_render_pipeline(
-            layout=self._device.create_pipeline_layout(
-                bind_group_layouts=[bind_group_layout]
-            ),
-            vertex={
-                "module": vertex_shader_program,
-                "entry_point": "main",
-                "buffers": [],
-            },
-            primitive={
-                "topology": wgpu.PrimitiveTopology.triangle_list,
-                "front_face": wgpu.FrontFace.ccw,
-                "cull_mode": wgpu.CullMode.none,
-            },
-            depth_stencil=None,
-            multisample=None,
-            fragment={
-                "module": frag_shader_program,
-                "entry_point": "main",
-                "targets": [
-                    {
-                        "format": wgpu.TextureFormat.bgra8unorm,
-                    },
-                ],
-            },
         )
 
     def _bind_events(self):
@@ -554,27 +265,8 @@ class Shadertoy:
             self._uniform_data.nbytes,
         )
 
-        command_encoder = self._device.create_command_encoder()
-        current_texture = self._present_context.get_current_texture()
-
-        render_pass = command_encoder.begin_render_pass(
-            color_attachments=[
-                {
-                    "view": current_texture.create_view(),
-                    "resolve_target": None,
-                    "clear_value": (0, 0, 0, 1),
-                    "load_op": wgpu.LoadOp.clear,
-                    "store_op": wgpu.StoreOp.store,
-                }
-            ],
-        )
-
-        render_pass.set_pipeline(self._render_pipeline)
-        render_pass.set_bind_group(0, self._bind_group, [], 0, 99)
-        render_pass.draw(3, 1, 0, 0)
-        render_pass.end()
-
-        self._device.queue.submit([command_encoder.finish()])
+        image_pass = self.image.draw()
+        self._device.queue.submit([image_pass])
 
         self._canvas.request_draw()
 

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -64,6 +64,12 @@ class UniformArray:
             for i in range(n):
                 m[i] = val[i]
 
+    def copy(self):
+        """
+        returns a copy of this object
+        """
+        return UniformArray
+
 
 class Shadertoy:
     """Provides a "screen pixel shader programming interface" similar to `shadertoy <https://www.shadertoy.com/>`_.
@@ -257,13 +263,6 @@ class Shadertoy:
         # Update uniform buffer
         if not self._offscreen:
             self._update()
-        self._device.queue.write_buffer(
-            self._uniform_buffer,
-            0,
-            self._uniform_data.mem,
-            0,
-            self._uniform_data.nbytes,
-        )
 
         image_pass = self.image.draw()
         self._device.queue.submit([image_pass])

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -147,8 +147,10 @@ class Shadertoy:
 
         # setting up the renderpasses, inputs to the main class get handed to the .image pass
         self.image = ImageRenderPass(
-            main=self, code=shader_code, shader_type=shader_type, inputs=inputs
+            code=shader_code, shader_type=shader_type, inputs=inputs
         )
+        # setting main for passes triggers the inputs to be attached and the render prepared.
+        self.image.main = self
 
     @property
     def resolution(self):

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -1,18 +1,15 @@
 import collections
 import ctypes
 import os
-import re
 import time
-from typing import List
 
-import wgpu
 from wgpu.gui.auto import WgpuCanvas, run
 from wgpu.gui.offscreen import WgpuCanvas as OffscreenCanvas
 from wgpu.gui.offscreen import run as run_offscreen
 
 from .api import shader_args_from_json, shadertoy_from_id
 from .passes import ImageRenderPass
-from .inputs import ShadertoyChannel, ShadertoyChannelTexture
+
 
 class UniformArray:
     """Convenience class to create a uniform array.
@@ -63,12 +60,6 @@ class UniformArray:
             assert isinstance(val, (tuple, list))
             for i in range(n):
                 m[i] = val[i]
-
-    def copy(self):
-        """
-        returns a copy of this object
-        """
-        return UniformArray
 
 
 class Shadertoy:
@@ -155,7 +146,9 @@ class Shadertoy:
         self._bind_events()
 
         # setting up the renderpasses, inputs to the main class get handed to the .image pass
-        self.image = ImageRenderPass(main=self, code=shader_code, shader_type=shader_type, inputs=inputs)
+        self.image = ImageRenderPass(
+            main=self, code=shader_code, shader_type=shader_type, inputs=inputs
+        )
 
     @property
     def resolution(self):


### PR DESCRIPTION
next piece of #30 

Moves the renderpass related code into it's own `passes.py` file, so it can easily be expanded for the remaining renderpass types.
I tried to put most code into the share base class, but this might move a bit once I have the bufferpass PR.

Not really happy with how uniform data is shared between renderpasses

*might* need to update the docstring for the main class to explain that code/inputs to the main class are used for the `image` renderpass