### PR TITLE
Improve and simplify shadercode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Added:
 Changed:
 * `ShadertoyChannel` is now more specific `ShadertoyChannelTexture` https://github.com/pygfx/shadertoy/pull/40
 
+Removed:
+* Removed GLSL uniform aliases in favor of just Shadertoy syntax https://github.com/pygfx/shadertoy/pull/42
+
 ### [v0.1.0] - 2024-01-21
 
 Fixed:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ To display a shader from the website, simply provide its ID or url.
 > wgpu-shadertoy tsXBzS --resolution 1024 640
 ```
 
+### Uniforms
+The Shadertoy uniform format is directly supported for GLSL. However for WGSL the syntax is a bit different.
+
+| Shadertoy.com | GLSL | WGSL |
+|--- | --- | --- |
+| `vec4 iMouse` | `iMouse` | `i_mouse` |
+| `vec4 iDate` | `iDate` | `i_date` |
+| `vec3 iResolution` | `iResolution` | `i_resolution` |
+| `float iTime` | `iTime` | `i_time` |
+| `vec3 iChannelResolution[4]` | `iChannelResolution` | `i_channel_resolution` |
+| `float iTimeDelta` | `iTimeDelta` | `i_time_delta` |
+| `int iFrame` | `iFrame` | `i_frame` |
+| `float iFrameRate` | `iFrameRate` | `i_frame_rate` |
+| `sampler2D iChannel0..3` | `iChannel0..3` | `i_channel0..3` |
+| `sampler3D iChannel0..3` | not yet supported | not yet supported |
+| `samplerCube iChannel0..3` | not yet supported | not yet supported |
+| `float iChannelTime[4]` | not yet supported | not yet supported |
+| `float iSampleRate` | not yet supported | not yet supported |
+
 ## Status
 
 This project is still in development. Some functionality from the Shadertoy [website is missing](https://github.com/pygfx/shadertoy/issues/4) and [new features](https://github.com/pygfx/shadertoy/issues/8) are being added. See the issues to follow the development or [contribute yourself](./CONTRIBUTING.md)! For progress see the [changelog](./CHANGELOG.md).

--- a/tests/test_textures.py
+++ b/tests/test_textures.py
@@ -60,7 +60,7 @@ def test_textures_glsl():
         vec2 uv = fragCoord/iResolution.xy;
         vec4 c0 = texture(iChannel0, 2.0*uv);
         vec4 c1 = texture(iChannel1, 3.0*uv);
-        fragColor = mix(c0,c1,abs(sin(i_time)));
+        fragColor = mix(c0,c1,abs(sin(iTime)));
     }
     """
 

--- a/tests/test_util_shadertoy.py
+++ b/tests/test_util_shadertoy.py
@@ -60,18 +60,19 @@ def test_shadertoy_glsl():
     from wgpu_shadertoy import Shadertoy
 
     shader_code = """
-        void shader_main(out vec4 fragColor, vec2 frag_coord) {
-            vec2 uv = frag_coord / i_resolution.xy;
+        void mainImage(out vec4 fragColor, vec2 fragCoord) {
+            vec2 uv = fragCoord / iResolution.xy;
 
-            if ( length(frag_coord - i_mouse.xy) < 20.0 ) {
+            if ( length(fragCoord - iMouse.xy) < 20.0 ) {
                 fragColor = vec4(0.0, 0.0, 0.0, 1.0);
             }else{
-                fragColor = vec4( 0.5 + 0.5 * sin(i_time * vec3(uv, 1.0) ), 1.0);
+                fragColor = vec4( 0.5 + 0.5 * sin(iTime * vec3(uv, 1.0) ), 1.0);
             }
 
         }
     """
 
+    # tests the shader_type detection base case we will most likely see.
     shader = Shadertoy(shader_code, resolution=(800, 450))
     assert shader.resolution == (800, 450)
     assert shader.image.shader_code == shader_code
@@ -97,6 +98,7 @@ def test_shadertoy_glsl2():
         }
     """
 
+    # this tests if setting the shader_type to glsl works as expected
     shader = Shadertoy(shader_code, shader_type="glsl", resolution=(800, 450))
     assert shader.resolution == (800, 450)
     assert shader.image.shader_code == shader_code
@@ -122,6 +124,7 @@ def test_shadertoy_glsl3():
         }
     """
 
+    # this tests glsl detection against the regular expression when using more than one whitespace between void and mainImage.
     shader = Shadertoy(shader_code, resolution=(800, 450))
     assert shader.resolution == (800, 450)
     assert shader.image.shader_code == shader_code
@@ -135,13 +138,13 @@ def test_shadertoy_offscreen():
     from wgpu_shadertoy import Shadertoy
 
     shader_code = """
-        void shader_main(out vec4 fragColor, vec2 frag_coord) {
-            vec2 uv = frag_coord / i_resolution.xy;
+        void mainImage(out vec4 fragColor, vec2 fragCoord) {
+            vec2 uv = fragCoord / iResolution.xy;
 
-            if ( length(frag_coord - i_mouse.xy) < 20.0 ) {
+            if ( length(fragCoord - iMouse.xy) < 20.0 ) {
                 fragColor = vec4(0.0, 0.0, 0.0, 1.0);
             }else{
-                fragColor = vec4( 0.5 + 0.5 * sin(i_time * vec3(uv, 1.0) ), 1.0);
+                fragColor = vec4( 0.5 + 0.5 * sin(iTime * vec3(uv, 1.0) ), 1.0);
             }
 
         }
@@ -159,13 +162,13 @@ def test_shadertoy_snapshot():
     from wgpu_shadertoy import Shadertoy
 
     shader_code = """
-        void shader_main(out vec4 fragColor, vec2 frag_coord) {
-            vec2 uv = frag_coord / i_resolution.xy;
+        void mainImage(out vec4 fragColor, vec2 fragCoord) {
+            vec2 uv = fragCoord / iResolution.xy;
 
-            if ( length(frag_coord - i_mouse.xy) < 20.0 ) {
+            if ( length(fragCoord - iMouse.xy) < 20.0 ) {
                 fragColor = vec4(0.0, 0.0, 0.0, 1.0);
             }else{
-                fragColor = vec4( 0.5 + 0.5 * sin(i_time * vec3(uv, 1.0) ), 1.0);
+                fragColor = vec4( 0.5 + 0.5 * sin(iTime * vec3(uv, 1.0) ), 1.0);
             }
 
         }

--- a/wgpu_shadertoy/inputs.py
+++ b/wgpu_shadertoy/inputs.py
@@ -35,7 +35,7 @@ class ShadertoyChannel:
             wrap = "clamp-to-edge"
         settings["address_mode_u"] = wrap
         settings["address_mode_v"] = wrap
-        # we don't do 3D textures yet, but I guess ssetting this too is fine.
+        # we don't do 3D textures yet, but I guess setting this too is fine.
         settings["address_mode_w"] = wrap
         return settings
 

--- a/wgpu_shadertoy/inputs.py
+++ b/wgpu_shadertoy/inputs.py
@@ -131,6 +131,35 @@ class ShadertoyChannel:
             },
         ]
 
+    def make_header(self, shader_type: str) -> str:
+        """
+        Constructs the glsl or wgsl code snippet that for the sampler and texture bindings.
+        """
+        # does this fallback ever happen?
+        if not shader_type:
+            shader_type = self.parent.shader_type
+        shader_type = shader_type.lower()
+
+        input_idx = self.channel_idx
+        binding_id = self.texture_binding
+        sampler_id = self.sampler_binding
+        if shader_type == "glsl":
+            return f"""
+            layout(binding = {binding_id}) uniform texture2D i_channel{input_idx};
+            layout(binding = {sampler_id}) uniform sampler sampler{input_idx};
+            
+            #define iChannel{input_idx} sampler2D(i_channel{input_idx}, sampler{input_idx})
+            """
+        elif shader_type == "wgsl":
+            return f"""
+            @group(0) @binding({binding_id})
+            var i_channel{input_idx}: texture_2d<f32>;
+            @group(0) @binding({sampler_id})
+            var sampler{input_idx}: sampler;
+            """
+        else:
+            raise ValueError(f"Unknown shader type: {shader_type}")
+
     def __repr__(self):
         """
         Convenience method to get a representation of this object for debugging.

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -7,32 +7,14 @@ from .inputs import ShadertoyChannel, ShadertoyChannelTexture
 
 builtin_variables_glsl = """#version 450 core
 
-vec4 i_mouse;
-vec4 i_date;
-vec3 i_resolution;
-float i_time;
-vec3 i_channel_resolution[4];
-float i_time_delta;
-int i_frame;
-float i_framerate;
-
-// Shadertoy compatibility, see we can use the same code copied from shadertoy website
-
-#define iChannel0 sampler2D(i_channel0, sampler0)
-#define iChannel1 sampler2D(i_channel1, sampler1)
-#define iChannel2 sampler2D(i_channel2, sampler2)
-#define iChannel3 sampler2D(i_channel3, sampler3)
-
-#define iMouse i_mouse
-#define iDate i_date
-#define iResolution i_resolution
-#define iTime i_time
-#define iChannelResolution i_channel_resolution
-#define iTimeDelta i_time_delta
-#define iFrame i_frame
-#define iFrameRate i_framerate
-
-#define mainImage shader_main
+vec4 iMouse;
+vec4 iDate;
+vec3 iResolution;
+float iTime;
+vec3 iChannelResolution[4];
+float iTimeDelta;
+int iFrame;
+float iFrameRate;
 """
 
 builtin_variables_wgsl = """
@@ -114,7 +96,7 @@ class RenderPass:
         """The shader type, automatically detected from the shader code, can be "wgsl" or "glsl"."""
         if self._shader_type not in ("wgsl", "glsl"):
             wgsl_main_expr = re.compile(r"fn(?:\s)+shader_main")
-            glsl_main_expr = re.compile(r"void(?:\s)+(?:shader_main|mainImage)")
+            glsl_main_expr = re.compile(r"void(?:\s)+mainImage")
             if wgsl_main_expr.search(self.shader_code):
                 self._shader_type = "wgsl"
             elif glsl_main_expr.search(self.shader_code):

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -285,7 +285,7 @@ class RenderPass:
         render_pass.end()
 
         return command_encoder.finish()
-    
+
     def construct_code(self) -> tuple[str, str]:
         """
         Public method to get the full vertex and fragment code for this renderpass.

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -14,7 +14,6 @@ from .passes import ImageRenderPass
 class UniformArray:
     """Convenience class to create a uniform array.
 
-    Maybe we can make it a public util at some point.
     Ensure that the order matches structs in the shader code.
     See https://www.w3.org/TR/WGSL/#alignment-and-size for reference on alignment.
     """
@@ -79,13 +78,13 @@ class Shadertoy:
 
     The shader code must contain a entry point function:
 
-    WGSL: ``fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{}``
-    GLSL: ``void shader_main(out vec4 frag_color, in vec2 frag_coord){}``
+    WGSL: ``fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{}`` <br>
+    GLSL: ``void mainImage(out vec4 fragColor, in vec2 fragCoord){}``
 
     It has a parameter ``frag_coord`` which is the current pixel coordinate (in range 0..resolution, origin is bottom-left),
-    and it must return a vec4<f32> color (for GLSL, it's the ``out vec4 frag_color`` parameter), which is the color of the pixel at that coordinate.
+    and it must return a vec4<f32> color (for GLSL, it's the ``out vec4 fragColor`` parameter), which is the color of the pixel at that coordinate.
 
-    some built-in variables are available in the shader:
+    some built-in uniforms are available in the shader:
 
     * ``i_mouse``: the mouse position in pixels
     * ``i_date``: the current date and time as a vec4 (year, month, day, seconds)
@@ -95,8 +94,8 @@ class Shadertoy:
     * ``i_frame``: the frame number
     * ``i_framerate``: the number of frames rendered in the last second.
 
-    For GLSL, you can also use the aliases ``iTime``, ``iTimeDelta``, ``iFrame``, ``iResolution``, ``iMouse``, ``iDate`` and ``iFrameRate`` of these built-in variables,
-    the entry point function also has an alias ``mainImage``, so you can use the shader code copied from shadertoy website without making any changes.
+    For GLSL, these uniforms are ``iTime``, ``iTimeDelta``, ``iFrame``, ``iResolution``, ``iMouse``, ``iDate`` and ``iFrameRate``,
+    the entry point function is ``mainImage``, so you can use the shader code copied from shadertoy website without making any changes.
     """
 
     # todo: add remaining built-in variables (i_channel_time)


### PR DESCRIPTION
Next part of #30 

* The shader code construction (vertex, builtin, fragment) is now handled via a public method so it can be used externally.
* Headers for inputs (bindings, samplers) are now dynamic via the input class. This will extend easier to more input channels like cubemaps and 3D samplers.
* dropped the glsl aliases (`i_time`, etc) only supporting Shadertoy syntax now (`iTime`). might help with #22 
* Uniform formats are also now documented in the README.

this removes some of the massive strings at the top of the file and might also reduce some overhead (which the compiler likely took care off anyway).