### PR TITLE
Add microphone/audio device input

### DIFF
--- a/examples/shadertoy_mic_input.py
+++ b/examples/shadertoy_mic_input.py
@@ -1,0 +1,40 @@
+import argparse
+from wgpu_shadertoy import Shadertoy
+from wgpu_shadertoy import NoiseAudioDevice, MicrophoneAudioDevice
+import sounddevice as sd
+import sys
+
+# Set up command line argument parsing
+parser = argparse.ArgumentParser(description='Run a Shadertoy shader with an audio input device.')
+parser.add_argument('--from_id', type=str, default="llSGDh", 
+                    help='Shadertoy ID (default: llSGDh) https://www.shadertoy.com/view/llSGDh by iq CC-BY-NC-SA-3.0')
+parser.add_argument('--list-audio-devices', action='store_true',
+                    help='List all available audio input devices and exit')
+parser.add_argument('--device-index', type=int, default=None,
+                    help='Audio device index to use (default: system default)')
+
+if __name__ == "__main__":
+    # Parse the command line arguments
+    args = parser.parse_args()
+
+    # If list-audio-devices flag is present, list devices and exit
+    if args.list_audio_devices:
+        print("Available audio input devices:")
+        print(sd.query_devices())
+        sys.exit(0)
+
+    # Use the provided ID or the default one
+    shader_id = args.from_id
+
+    # Use the device index from command line if provided
+    # if device_index is None, sounddevice will use the system default device
+    device_index = args.device_index
+
+    # Create microphone audio device with specified device index (or None for default)
+    #   We could use a NoiseAudioDevice for testing without a mic: audio_device = NoiseAudioDevice(rate=44100)
+    audio_device = MicrophoneAudioDevice(device_index=device_index, sample_rate=44100, buffer_duration_seconds=2.0)
+    audio_device.start()
+
+    # shadertoy source: https://www.shadertoy.com/view/llSGDh by iq CC-BY-NC-SA-3.0
+    shader = Shadertoy.from_id(shader_id, use_cache=True, audio_device=audio_device)
+    shader.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "requests",
   "numpy",
   "Pillow",
+  "sounddevice",
 ]
 description = "Shadertoy implementation based on wgpu-py"
 license = {file = "LICENSE"}

--- a/wgpu_shadertoy/__init__.py
+++ b/wgpu_shadertoy/__init__.py
@@ -1,6 +1,7 @@
 from .inputs import ShadertoyChannel, ShadertoyChannelTexture
 from .passes import ImageRenderPass
 from .shadertoy import Shadertoy
+from .audio_devices import AudioDevice, FIFOPushAudioDevice, NullAudioDevice, NoiseAudioDevice, MicrophoneAudioDevice
 
 __version__ = "0.1.0"
 version_info = tuple(map(int, __version__.split(".")))

--- a/wgpu_shadertoy/api.py
+++ b/wgpu_shadertoy/api.py
@@ -81,6 +81,8 @@ def _download_media_channels(
                 if use_cache:
                     img.save(cache_path)
             args = {"data": img}
+        elif inp["ctype"] == "mic":
+            args = {}
         else:
             complete = False
             continue  # skip the below rows

--- a/wgpu_shadertoy/audio_devices.py
+++ b/wgpu_shadertoy/audio_devices.py
@@ -1,0 +1,233 @@
+import numpy as np
+from abc import ABC, abstractmethod
+from collections import deque
+import sounddevice as sd
+# import logging
+
+# logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(name)s:%(message)s')
+# log = logging.getLogger(__name__)
+
+class AudioDevice(ABC):
+    """
+    Abstract Base Class for audio input devices used by ShadertoyChannelMusic.
+    """
+
+    @abstractmethod
+    def get_samples(self, num_samples: int) -> np.ndarray:
+        """
+        Retrieve the most recent audio samples.
+
+        Args:
+            num_samples (int): The number of samples required.
+
+        Returns:
+            np.ndarray: A 1D numpy array of float32 audio samples (ideally [-1, 1]),
+                        of length `num_samples`. If fewer samples are available than
+                        requested, implementations should pad appropriately (e.g., with zeros).
+        """
+        pass
+
+    @abstractmethod
+    def get_rate(self) -> int:
+        """
+        Returns the sample rate of the audio device in Hz.
+        """
+        pass
+
+    def start(self):
+        """
+        Start the audio device (e.g., open microphone stream).
+        Optional: Base implementation does nothing.
+        """
+        pass
+
+    def stop(self):
+        """
+        Stop the audio device (e.g., close microphone stream).
+        Optional: Base implementation does nothing.
+        """
+        pass
+
+    def is_ready(self) -> bool:
+        """
+        Check if the device is ready or has sufficient data.
+        Optional: Base implementation assumes always ready.
+        """
+        return True
+    
+    def gain(self) -> float:
+        """
+        Returns the gain factor for the audio device.
+        Optional: Base implementation returns 1.0 (no gain).
+        """
+        return 1.0
+    
+class FIFOPushAudioDevice(AudioDevice):
+    """
+    An AudioDevice implementation using an internal FIFO buffer (deque).
+    Samples are added using the `push_samples` method.
+    """
+    def __init__(self, rate: int, max_buffer_samples: int, gain: float = 0.6):
+        self._gain = gain
+        self._rate = rate
+        # Buffer stores slightly more than needed for FFT to handle requests
+        self._buffer = deque(maxlen=max_buffer_samples)
+
+    def get_rate(self) -> int:
+        return self._rate
+
+    def push_samples(self, new_samples: np.ndarray):
+        """Appends new audio samples to the internal buffer."""
+        # Ensure input is float32? Or handle conversion? Assume float for now.
+        self._buffer.extend(new_samples.astype(np.float32))
+
+    def get_samples(self, num_samples: int) -> np.ndarray:
+        """Returns the most recent `num_samples` from the buffer."""
+        current_buffer = np.array(self._buffer) # Convert deque to numpy array for slicing
+        available_samples = current_buffer.size
+
+        if available_samples >= num_samples:
+            # Return the last num_samples
+            return current_buffer[-num_samples:]
+        else:
+            # Not enough samples, return what we have padded with leading zeros
+            padded_samples = np.zeros(num_samples, dtype=np.float32)
+            if available_samples > 0:
+                padded_samples[-available_samples:] = current_buffer
+            return padded_samples
+
+    def is_ready(self) -> bool:
+        # Consider ready if buffer has at least enough samples for typical request?
+        # Let's say ready if buffer has at least 512 samples (typical fft_input_size)
+        return len(self._buffer) >= 512
+    
+    def gain(self) -> float:
+        return self._gain
+    
+class NullAudioDevice(AudioDevice):
+    """An AudioDevice that always returns silence."""
+    def __init__(self, rate: int = 44100):
+        self._rate = rate
+
+    def get_rate(self) -> int:
+        return self._rate
+
+    def get_samples(self, num_samples: int) -> np.ndarray:
+        return np.zeros(num_samples, dtype=np.float32)
+    
+class NoiseAudioDevice(AudioDevice):
+    """An AudioDevice that always returns silence."""
+    def __init__(self, rate: int = 44100):
+        self._rate = rate
+
+    def get_rate(self) -> int:
+        return self._rate
+
+    def get_samples(self, num_samples: int) -> np.ndarray:
+        return np.random.uniform(-1, 1, num_samples).astype(np.float32)
+    
+class MicrophoneAudioDevice(FIFOPushAudioDevice):
+    """
+    An AudioDevice implementation that reads live audio from a system input device
+    using the `sounddevice` library. Provides single-channel (mono) float32 samples.
+    """
+    def __init__(self,
+                 sample_rate: int = 44100,
+                 buffer_duration_seconds: float = 5.0,
+                 chunk_size: int = 1024,
+                 device_index: int | None = None,
+                 gain: float = 0.6):
+        """
+        Initializes the MicrophoneAudioDevice.
+
+        Args:
+            sample_rate (int): The desired sample rate in Hz.
+            buffer_duration_seconds (float): The duration of the internal FIFO buffer
+                                             in seconds. Determines the maximum amount
+                                             of recent audio history stored.
+            chunk_size (int): The number of samples to read from the audio device
+                              in each callback chunk. Affects latency and overhead.
+            device_index (int | None): The index of the input audio device to use.
+                                       If None, the default system input device is used.
+                                       Use `sounddevice.query_devices()` to list devices.
+            gain (float): The gain factor to apply to the audio fft data.
+        """
+        max_samples = int(sample_rate * buffer_duration_seconds)
+        super().__init__(rate=sample_rate, max_buffer_samples=max_samples, gain=gain)
+
+        self._chunk_size = chunk_size
+        self._device_index = device_index
+        self._stream = None
+        # print(f"MicrophoneAudioDevice initialized. Rate: {sample_rate} Hz, "
+        #          f"Buffer: {buffer_duration_seconds}s ({max_samples} samples), "
+        #          f"Chunk Size: {chunk_size}, Device: {device_index or 'Default'}")
+
+    def _audio_callback(self, indata: np.ndarray, frames: int, time, status: sd.CallbackFlags):
+        """
+        This function is called by sounddevice in a separate thread
+        whenever new audio data is available.
+        """
+        if status:
+            print(f"Warning: Sounddevice callback status: {status}")
+            if status.input_underflow: print(f"Warning: Input underflow detected!")
+            if status.input_overflow: print(f"Warning: Input overflow detected! Buffer might be too small or processing too slow.")
+
+        # indata comes in as float32 (due to dtype='float32' in stream)
+        # It might be multi-channel, but we requested channels=1,
+        # so it should have shape (frames, 1). We need 1D.
+        if indata.shape[1] != 1:
+             # This shouldn't happen if channels=1 works, but as a fallback:
+             mono_samples = indata.mean(axis=1).astype(np.float32)
+        else:
+             mono_samples = indata[:, 0] # Extract the single channel, makes it 1D
+
+        # Push the mono samples into the deque buffer (managed by parent class)
+        # This uses self._buffer.extend(), which is thread-safe in CPython.
+        self.push_samples(mono_samples)
+
+    def start(self):
+        """Starts the audio stream from the microphone."""
+        if self._stream is not None and self._stream.active:
+            print("Warning: Stream already running. Call stop() first if you want to restart.")
+            return
+
+        try:
+            self._stream = sd.InputStream(
+                samplerate=self.get_rate(),
+                blocksize=self._chunk_size,
+                device=self._device_index,
+                channels=1,  # Request mono directly
+                dtype=np.float32, # Request 32-bit float
+                callback=self._audio_callback,
+                latency='low' # Or 'high' for potentially more stable streaming
+            )
+            self._stream.start()
+        except Exception as e:
+            print(f"Error: Failed to start audio stream: {e}")
+            self._stream = None # Ensure stream is None if start failed
+            # Re-raise the exception if the calling code needs to know
+            raise e
+
+    def stop(self):
+        """Stops the audio stream."""
+        if self._stream is None:
+            return
+
+        try:
+            if self._stream.active:
+                self._stream.stop()
+            self._stream.close()
+        except Exception as e:
+            print(f"Error: stopping audio stream: {e}")
+        finally:
+            # Ensure stream is marked as stopped regardless of errors
+            self._stream = None
+
+    # Optional: Override is_ready to also check the stream status
+    def is_ready(self) -> bool:
+        """Check if the stream is active and the buffer has sufficient data."""
+        parent_ready = super().is_ready()
+        stream_active = self._stream is not None and self._stream.active
+        # TODO - allow getting samples
+        # even if stream just stopped but buffer is full.
+        return stream_active and parent_ready

--- a/wgpu_shadertoy/inputs.py
+++ b/wgpu_shadertoy/inputs.py
@@ -1,8 +1,9 @@
 from typing import Tuple
 
 import numpy as np
+from numpy.fft import rfft
 import wgpu
-
+from .audio_devices import AudioDevice, NullAudioDevice
 
 class ShadertoyChannel:
     """
@@ -21,7 +22,7 @@ class ShadertoyChannel:
         self._channel_idx = channel_idx
         self.args = args
         self.kwargs = kwargs
-        self.dynamic: bool = False
+        self.dynamic: bool = kwargs.pop("dynamic", False)
 
     @property
     def sampler_settings(self) -> dict:
@@ -93,12 +94,21 @@ class ShadertoyChannel:
         # TODO: automatically infer from the provided data/file/link/name or code.
         args = self.args + args_
         kwargs = {**self.kwargs, **kwargs_}
+        
         if self.ctype is None or not hasattr(self, "ctype"):
             raise NotImplementedError("Can't dynamically infer the ctype yet")
         if self.ctype == "texture":
             return ShadertoyChannelTexture(*args, **kwargs)
+        elif self.ctype == "mic":
+            return ShadertoyChannelMusic(*args, **kwargs)
         else:
             raise NotImplementedError(f"Doesn't support {self.ctype=} yet")
+
+    def _update_input(self, time, time_delta):
+        """
+        Updates the input channel. This is called by the parent renderpass.
+        """
+        pass
 
     # TODO: can this be avoided?
     def _binding_layout(self):
@@ -298,4 +308,286 @@ class ShadertoyChannelVideo(ShadertoyChannel):
 
 
 class ShadertoyChannelMusic(ShadertoyChannel):
-    pass
+    """
+    Represents a Shadertoy music input channel (iChannel for audio).
+    Uses an AudioDevice to fetch samples and updates a 2D texture
+    (typically 512x2, rg32float) with FFT and Waveform data.
+
+    Data Layout:
+    - The internal NumPy array has shape (height, width, components),
+      e.g., (2, 512, 2) for float32 dtype.
+    - Component 0 (R channel), Row 0 (y~0.25): Contains FFT data [0, 1].
+    - Component 0 (R channel), Row 1 (y~0.75): Contains Waveform data (often normalized to [0, 1]).
+    - Component 1 (G channel): Currently unused (contains zeros).
+    - In the shader (GLSL):
+        - Access FFT via `texture(iChannel0, vec2(u, 0.25)).r` (or .x)
+        - Access Wave via `texture(iChannel0, vec2(u, 0.75)).r` (or .x)
+      (Texture coordinates assume y=0 is bottom, y=1 is top;
+       0.25 targets the middle of the first row, 0.75 targets the middle of the second row).
+
+    Parameters:
+        audio_device (AudioDevice): An instance of an AudioDevice subclass
+                                    providing the audio samples.
+        size (tuple): Texture size as (width, height), e.g., (512, 2).
+                      Width determines the texture resolution for wave/FFT.
+        dynamic (bool): If True, allows the texture to be updated later. Default is True.
+        **kwargs: Additional arguments passed to the base ShadertoyChannel.
+    """
+
+    def __init__(self, size=(512, 2), dynamic=True, **kwargs):
+            kwargs['ctype'] = 'music'
+            # Ensure dynamic is True if we have an audio device providing updates
+            super().__init__(dynamic=dynamic, **kwargs)
+
+            # check if kwargs has 'audio_device' and set it
+            audio_device = kwargs.pop("audio_device", None)
+
+            if audio_device is None:
+                # use the NULL audio device
+                audio_device = NullAudioDevice(44100)
+
+            self.audio_device = audio_device
+            self.format = wgpu.TextureFormat.rg32float
+            self._num_components = 2
+            self._gain = self.audio_device.gain()
+
+            self.texture_width, self.texture_height = size
+            if self.texture_height != 2:
+                print(f"Warning: ShadertoyChannelMusic typically uses height=2 (FFT, Wave), got {self.texture_height}")
+
+            # Initialize placeholder data matching texture structure
+            self.data = np.zeros((self.texture_height, self.texture_width, self._num_components), dtype=np.float32)
+            self.texture_size = (self.texture_width, self.texture_height, 1)
+
+            self._texture = None
+            self._device = None
+
+    @property
+    def channel_res(self) -> Tuple[int, int, int, int]:
+        """
+        Returns the resolution of the channel texture: (width, height, depth=1, padding=-99)
+        """
+        return (self.texture_size[0], self.texture_size[1], 1, -99)
+
+    @property
+    def size(self) -> Tuple:
+        """ Size of the data array (height, width, components) """
+        return self.data.shape
+
+    def bind_texture(self, device: wgpu.GPUDevice) -> Tuple[list, list]:
+        """
+        Prepares the texture and sampler for the audio data.
+        Returns its binding layouts and bindgroup layout entries.
+        """
+        self._device = device # Store device reference for updates
+
+        binding_layout = self._binding_layout()
+
+        usage = wgpu.TextureUsage.TEXTURE_BINDING | wgpu.TextureUsage.COPY_DST
+
+        if self.dynamic:
+            usage |= wgpu.TextureUsage.COPY_DST
+
+        # Create the texture only if it doesn't exist
+        if self._texture is None:
+            self._texture = device.create_texture(
+                size=self.texture_size,
+                format=self.format,
+                usage=usage,
+                label="shadertoy-music-channel"
+            )
+
+            # Perform initial write
+            bytes_per_row = self.texture_size[0] * self._num_components * self.data.itemsize
+            if bytes_per_row % 256 != 0:
+                 bytes_per_row += 256 - (bytes_per_row % 256)
+
+            device.queue.write_texture(
+                destination={"texture": self._texture, "mip_level": 0, "origin": (0, 0, 0)},
+                data=self.data,
+                data_layout={
+                    "bytes_per_row": bytes_per_row,
+                    "rows_per_image": self.texture_size[1], # height
+                },
+                size=self.texture_size, # (width, height, depth)
+            )
+
+        texture_view = self._texture.create_view()
+        sampler = device.create_sampler(**self.sampler_settings)
+
+        bind_groups_layout_entry = self._bind_groups_layout_entries(
+            texture_view, sampler
+        )
+
+        return binding_layout, bind_groups_layout_entry
+
+    def update(self, new_data: np.ndarray):
+        """
+        Updates the texture data with a pre-formatted NumPy array.
+        The array must have the shape (height, width, 2) and dtype (float32).
+
+        Args:
+            new_data: New audio data (e.g., shape (2, 512, 2), dtype float32).
+        """
+        if not self.dynamic:
+            raise TypeError("This ShadertoyChannelMusic was not initialized with dynamic=True")
+        if self._texture is None or self._device is None:
+            raise RuntimeError("Texture hasn't been bound to a device yet via bind_texture()")
+
+        new_data = np.asarray(new_data, dtype=np.float32)
+        if new_data.shape != self.data.shape:
+             raise ValueError(f"New data shape {new_data.shape} must match original shape {self.data.shape}")
+
+        new_data_contiguous = np.ascontiguousarray(new_data)
+        self.data = new_data # Update internal reference if needed outside
+
+        bytes_per_row = self.texture_size[0] * self._num_components * new_data_contiguous.itemsize
+        if bytes_per_row % 256 != 0:
+            bytes_per_row += 256 - (bytes_per_row % 256)
+
+        self._device.queue.write_texture(
+            destination={"texture": self._texture, "mip_level": 0, "origin": (0, 0, 0)},
+            data=new_data_contiguous,
+            data_layout={
+                "bytes_per_row": bytes_per_row,
+                "rows_per_image": self.texture_size[1], # height
+            },
+            size=self.texture_size, # (width, height, depth)
+        )
+
+    def update_from_audio(self, rate: int, samples: np.ndarray):
+        """
+        Processes raw audio samples to generate FFT and Waveform data,
+        then updates the internal texture. Both FFT and Waveform are
+        packed into the first component (R channel) of their respective rows.
+
+        Args:
+            rate (int): The sample rate of the audio data. (Currently unused in processing)
+            samples (np.ndarray): A 1D NumPy array of float32 audio samples.
+                                  Should have length == fft_input_size.
+        """
+        # Keep the checks here as this method might be called externally too
+        if not self.dynamic:
+            # print("Warning: Calling update_from_audio on non-dynamic channel.") # Debug
+            return
+        if self._texture is None or self._device is None:
+            print("Warning: update_from_audio called before texture is bound.")
+            return
+
+        target_width = self.texture_width
+        fft_input_size = target_width * 2
+
+        # --- Assume 'samples' already has the correct length (fft_input_size) ---
+        # The check for length should happen in the caller (_update_input)
+
+        # --- Process Waveform Data ---
+        # Use the *last* target_width samples from the input buffer
+        wave_segment = samples[-target_width:]
+        # Normalize waveform to [0, 1] range for .x access in shader
+        wave_segment_normalized = (np.clip(wave_segment, -1.0, 1.0) + 1.0) * 0.5
+
+        # --- Process FFT Data ---
+        fft_segment = samples
+        window = np.hanning(fft_input_size)
+        fft_segment_windowed = fft_segment * window
+        fft_result = rfft(fft_segment_windowed)
+        fft_magnitude = np.abs(fft_result[1:target_width+1]) # Skip DC
+
+        # Apply square root to magnitude to boost lower values
+        fft_sqrt_magnitude = np.sqrt(fft_magnitude)
+
+        # Normalize/Scale: Adjust this scaling factor based on visual results
+        # This factor depends heavily on the input audio level and desired visual range.
+        fft_processed = fft_sqrt_magnitude * self._gain
+
+        # Clip to ensure the final value is in the [0, 1] range for the texture
+        fft_final = np.clip(fft_processed, 0.0, 1.0)
+
+        # --- Format for Texture ---
+        texture_data = np.zeros((self.texture_height, self.texture_width, self._num_components), dtype=np.float32)
+
+        if self.texture_height == 2:
+            # Store FFT in the first row (index 0), R component (index 0)
+            texture_data[0, :, 0] = fft_final
+            # Store Waveform in the second row (index 1), R component (index 0)
+            texture_data[1, :, 0] = wave_segment_normalized
+        else:
+             print(f"Warning: update_from_audio packing only implemented for height=2")
+             if self.texture_height == 1:
+                  texture_data[0, :, 0] = fft_final
+                  # Decide how to pack wave for height=1, maybe G?
+                  # texture_data[0, :, 1] = wave_segment_normalized
+
+        # --- Update GPU Texture ---
+        # Call the existing self.update method which handles the wgpu call
+        self.update(texture_data)
+
+
+    # --- _update_input now fetches data and calls update_from_audio ---
+    def _update_input(self, time: float, time_delta: float):
+        """
+        Fetches the latest audio samples from the audio device and triggers
+        the processing and texture update via update_from_audio.
+        Called by the parent renderpass before drawing.
+
+        Args:
+            time (float): Current shader time (iTime).
+            time_delta (float): Time since last frame (iTimeDelta).
+        """
+        # Keep initial checks
+        if not self.dynamic:
+            return
+        if not self.audio_device.is_ready():
+            return
+        if self._texture is None or self._device is None:
+            print("Warning: _update_input called before texture is bound.")
+            return
+
+        # Determine how many samples are needed for processing
+        target_width = self.texture_width
+        fft_input_size = target_width * 2
+        rate = self.audio_device.get_rate()
+
+        # Fetch the required number of samples from the device
+        samples = self.audio_device.get_samples(fft_input_size)
+
+        # Ensure we got the right amount (device might pad if not enough)
+        # This check ensures update_from_audio receives the expected size
+        if samples.size != fft_input_size:
+             print(f"Warning: Audio device returned {samples.size} samples, expected {fft_input_size}. Padding.")
+             temp_samples = np.zeros(fft_input_size, dtype=np.float32)
+             valid_samples = min(samples.size, fft_input_size)
+             temp_samples[-valid_samples:] = samples[-valid_samples:]
+             samples = temp_samples
+
+        # --- Delegate processing and GPU update to update_from_audio ---
+        self.update_from_audio(rate, samples)
+
+    def _binding_layout(self):
+        return [
+            {
+                "binding": self.texture_binding,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "texture": {
+                    "sample_type": wgpu.TextureSampleType.unfilterable_float,
+                    "view_dimension": wgpu.TextureViewDimension.d2,
+                    "multisampled": False,
+                },
+            },
+            {
+                "binding": self.sampler_binding,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "sampler": {"type": wgpu.SamplerBindingType.non_filtering},
+            },
+        ]
+
+    @property
+    def sampler_settings(self) -> dict:
+        settings = super().sampler_settings
+        # we're using Rg32Float so we probably won't be able to filter:
+        # settings["mag_filter"] = wgpu.FilterMode.linear
+        # settings["min_filter"] = wgpu.FilterMode.linear
+        settings["address_mode_u"] = wgpu.AddressMode.clamp_to_edge
+        settings["address_mode_v"] = wgpu.AddressMode.clamp_to_edge
+        settings["address_mode_w"] = wgpu.AddressMode.clamp_to_edge
+        return settings

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -3,7 +3,7 @@ from typing import List
 
 import wgpu
 
-from .inputs import ShadertoyChannel, ShadertoyChannelTexture
+from .inputs import ShadertoyChannel, ShadertoyChannelTexture, ShadertoyChannelMusic
 
 builtin_variables_glsl = """#version 450 core
 
@@ -135,7 +135,7 @@ class RenderPass:
                 channel = None
             elif type(inp) is ShadertoyChannel:
                 # case where the base class is provided
-                channel = inp.infer_subclass(parent=self, channel_idx=inp_idx)
+                channel = inp.infer_subclass(parent=self, channel_idx=inp_idx, audio_device=self.main.audio_device)
             elif isinstance(inp, ShadertoyChannel):
                 # case where a subclass is provided
                 inp.channel_idx = inp_idx
@@ -250,6 +250,16 @@ class RenderPass:
         Updates uniforms and encodes the draw calls for this renderpass.
         Returns the command buffer.
         """
+
+        uniform_data = self.main._uniform_data
+        current_time = uniform_data["time"]
+        current_time_delta = uniform_data["time_delta"]
+
+        # call the update_input for each input channel
+        for channel in self.channels:
+            if channel is not None and channel.dynamic:
+                channel._update_input(current_time, current_time_delta)
+
         # to keep channel_res per renderpass - we need to overwrite it? (really lazy implementation)
         # channel_res can change with resizing, so it's not neccassarily constant
         # we might be able to reorder the layout and then cleverly use offsets

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -9,7 +9,7 @@ from wgpu.gui.offscreen import run as run_offscreen
 
 from .api import shader_args_from_json, shadertoy_from_id
 from .passes import ImageRenderPass
-
+from .audio_devices import AudioDevice, NullAudioDevice
 
 class UniformArray:
     """Convenience class to create a uniform array.
@@ -111,6 +111,7 @@ class Shadertoy:
         inputs=[],
         title: str = "Shadertoy",
         complete: bool = True,
+        audio_device: AudioDevice = None,
     ) -> None:
         self._uniform_data = UniformArray(
             ("mouse", "f", 4),
@@ -127,6 +128,7 @@ class Shadertoy:
         self.common = common + "\n"
         self._uniform_data["resolution"] = (*resolution, 1)
         self._shader_type = shader_type.lower()
+        self.audio_device = audio_device if audio_device is not None else NullAudioDevice(44100)
 
         # if no explicit offscreen option was given
         # inherit wgpu-py force offscreen option


### PR DESCRIPTION
This adds an abstract audio device class with a sub-class that creates an audio device using the sounddevice package.

ShadertoyChannelMusic is implemented to pull the audio data from it's given audio device and generates the waveform and fft data.

infer_subclass detects ctype of 'mic' and creates the ShadertoyChannelMusic instance.

An example (shadertoy/examples/shadertoy_mic_input.py) was added that demonstrates how to select and add the audio device to the ShaderToy instance.