### PR TITLE
[WIP] add imgui controls for define macros

### DIFF
--- a/examples/example_imgui.py
+++ b/examples/example_imgui.py
@@ -1,0 +1,160 @@
+from wgpu_shadertoy import Shadertoy
+
+# shadertoy source: https://www.shadertoy.com/view/dllyzH by timmaffett at CC-BY-NC-SA 3.0 (
+
+
+shader_code = """
+// Fork of "圆形烟花" by houkinglong. https://shadertoy.com/view/dlsyRr
+// 2023-07-27 05:32:56
+
+#define HARDNESS 60.0
+#define AMOUNT 90
+#define MAX_DISTANCE 20.0
+#define SPEED 0.15
+
+#define PI  3.14159265359
+#define TAU 6.28318530717
+vec3 hsb2rgb( in vec3 c )
+{
+    vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),
+                             6.0)-3.0)-1.0,
+                     0.0,
+                     1.0 );
+    rgb = rgb*rgb*(3.0-2.0*rgb);
+    return (c.z * mix( vec3(1.0), rgb, c.y));
+}
+
+
+// https://iquilezles.org/articles/smin
+float smin(float a, float b, float k) {
+    float res = exp2(-k * a) + exp2(-k * b);
+    return -log2(res) / k;
+}
+
+float sdCircle(vec2 uv, vec2 pos, float radius) {
+    return length(uv - pos) - radius;
+}
+
+float sdLine(vec2 uv, vec2 start, vec2 end) {
+    return 0.0;
+}
+
+float randomSingle(vec2 p) {
+    p = fract(p * vec2(233.34, 851.73));
+    p += dot(p, p + 23.45);
+    return fract(p.x * p.y);
+}
+
+vec4 randomPoint(vec2 p) {
+    float x = randomSingle(p);
+    float y = randomSingle(vec2(x, p.x));
+    return vec4(x, y, randomSingle(vec2(y, x)), randomSingle(vec2(x, y)));
+}
+
+float Star(vec2 uv, float dist, vec2 id) {
+    vec4 rand = randomPoint(id);
+
+    float progress = fract(iTime * SPEED + rand.z);
+
+    vec2 dir = 2.0 * (normalize(rand.xy) - 0.5);
+
+    rand.w = clamp((rand.w - 0.5) * 999.0, -1.0, 1.0);
+    dir *= rand.w;
+
+    return smin(dist, sdCircle(uv, dir * progress * MAX_DISTANCE, 0.001) / (progress + 0.7), 200.0);
+}
+
+float Graph(vec2 uv, float r) {
+    float dist = sdCircle(uv, vec2(0.0, 0.0), r);
+
+    dist = Star(uv, dist, vec2(1.0, 1.0));
+
+    for (int s = 1; s < AMOUNT; ++s)
+        dist = Star(uv, dist, vec2(-1.0, s));
+
+    dist *= HARDNESS;
+
+    dist = max(dist, 0.0);
+    dist = 1.0 / (dist + 0.001);
+    dist *= clamp(0.8, 0.98, length(uv));
+
+    return dist;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = (fragCoord * 2.0 - iResolution.xy) / iResolution.y;
+
+
+    float angle = iTime * 0.4;
+
+    // compute angle for pixel and to hsv color
+    vec2 center = iResolution.xy /2.0;
+    vec2 toRing = normalize(fragCoord.xy - center);
+    float ringValue = atan(toRing.x, -toRing.y);
+    ringValue /= PI;
+    ringValue = 1. - ringValue;
+    float ringAngle = ringValue / 2.0; // scale to hsv func
+    vec3 hsv = hsb2rgb(vec3(ringAngle+angle, 0.85, 0.96));
+    
+    // 一个像素的大小
+    float scale = 1.0 / iResolution.y;
+
+    // 外圆半径
+    float outerRadius = 0.99;
+    // 内圆半径
+    float innerRadius = 0.3;
+
+    // 色值声明
+    vec3 col = vec3(0);
+    //vec3 colR = vec3(1.0, 0.0, 0.0);
+    //vec3 colG = vec3(0.0, 0.3, 0.0);
+    vec3 colB = vec3(0.2);//vec3(0.01, 0.13, 0.32);// hsv*0.1;//rotate outer ring color
+
+    float dis = length(uv);
+
+    // 圆底
+    float bg = smoothstep(scale, -scale, sdCircle(uv, vec2(0.0, 0.0), outerRadius));
+    col = mix( vec3(0.0), colB, bg);
+
+    // 渐变环
+    float ring = smoothstep(outerRadius - 0.2, outerRadius, dis);
+    col *= ring;
+
+    if (dis > outerRadius) {
+        fragColor = vec4(hsv,1.) * 0.1;//vec4(0.0);
+        return;
+    }
+
+
+
+#define COLORCENTER
+#ifdef COLORCENTER
+     if (dis < innerRadius/2.9) {
+         fragColor = vec4(hsb2rgb(vec3(ringAngle+angle, 0.85, 0.96)),1.0);//vec4(0.0, 0.1, 0.2, 1.);
+         return;
+     }
+#endif
+
+    // 增加旋转
+    float sinA = sin(angle);
+    float cosA = cos(angle);
+    mat2 rot = mat2(cosA, -sinA, sinA, cosA);
+    uv *= rot;
+
+    uv *= 3.0;
+
+    float m = Graph(uv, innerRadius);
+
+    vec3 tint = hsb2rgb(vec3(ringAngle+angle, 0.85, 0.96));//hsv;//vec3(0.0, 0.0, 1.0);
+
+    col += m * mix(tint, tint*0.8/*vec3(1.0, 1.0, 1.0)*/, m);
+
+    fragColor = vec4(col, 1.0);
+}
+"""
+
+shader = Shadertoy(shader_code, resolution=(800, 450), imgui=True)
+
+
+if __name__ == "__main__":
+    shader.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "wgpu-shadertoy"
 dynamic = ["version", "readme"]
 dependencies = [
-  "wgpu>=0.21.1",
+  "wgpu[imgui]>=0.21.1",
   "rendercanvas",
   "requests",
   "numpy",

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -117,7 +117,7 @@ def get_default_adapter_summary():
 def find_examples(query=None, negative_query=None, return_stems=False):
     result = []
     for example_path in examples_dir.glob("*.py"):
-        example_code = example_path.read_text()
+        example_code = example_path.read_text(encoding="utf-8")
         query_match = query is None or query in example_code
         negative_query_match = (
             negative_query is None or negative_query not in example_code

--- a/wgpu_shadertoy/cli.py
+++ b/wgpu_shadertoy/cli.py
@@ -17,12 +17,20 @@ argument_parser.add_argument(
     default=(800, 450),
 )
 
+argument_parser.add_argument(
+    "--imgui",
+    help="automatically turn constants into imgui sliders",
+    action="store_true",
+)
+
 
 def main_cli():
     args = argument_parser.parse_args()
     shader_id = args.shader_id
     resolution = args.resolution
-    shader = Shadertoy.from_id(shader_id, resolution=resolution)
+    imgui = args.imgui
+    # TODO maybe **args?
+    shader = Shadertoy.from_id(shader_id, resolution=resolution, imgui=imgui)
     shader.show()
 
 

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -1,0 +1,41 @@
+import re
+
+# could imgui become just another RenderPass after Image? I got to understand backend vs renderer first.
+
+# todo: raise error if imgui isn't installed (only if this module is required?)
+
+
+def parse_constants(code, common_code):
+    # todo:
+    # WGSL variants??
+    # re/tree-sitter/loops and functions?
+    # parse and collect constants from shadercode (including common pass?)
+    # get information about the line, the type and it's initial value
+    # make up a range (maybe just the order of magnitude + 1 as max and 0 as min (what about negative values?))
+    # what is the return type? (line(int), type(str), value(float/tuple/int?)) maybe proper dataclasss for once
+    
+    # mataches the macro: #define NAME VALUE
+    define_pattern = re.compile(r"#define\s+(\w+)\s+(.+)")
+
+    constants = []
+    for line in code.splitlines():
+        match = define_pattern.match(line.rstrip())
+        if match:
+            constants.append(match.groups())
+            name, value = match.groups()
+            print(f"Found constant: {name} with value: {value}")
+
+    return constants
+
+def make_uniform(constants):
+    # todo:
+    # figure out order due to padding/alignment: https://www.w3.org/TR/WGSL/#alignment-and-size
+    # return a UniformArray object (cycling import?)
+    # (does this need to be a class to update the values?)
+    pass
+
+# imgui stuff
+def update_gui():
+    # todo: look at exmaples nad largely copy nad paste, will be called in the draw_frame function I think.
+
+    pass

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -116,12 +116,13 @@ def construct_imports(constants: list[ShaderConstant], constant_binding_idx=10) 
         var_init_lines.append(f"{const.shader_dtype} {const.name};")
         var_mapping_lines.append(f"# define {const.name} const_input.{const.name}")
 
+    new_line = "\n" # pytest was complaining about having blackslash in an f-string
     code_construct = f"""
     uniform struct ConstantInput {{
-        {'\n'.join(var_init_lines)}
+        {new_line.join(var_init_lines)}
     }};
     layout(binding = {constant_binding_idx}) uniform ConstantInput const_input;
-    {"\n".join(var_mapping_lines)}
+    {new_line.join(var_mapping_lines)}
     """
     # TODO messed up indentation...
     return code_construct

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -1,5 +1,8 @@
 import re
+from imgui_bundle import imgui as ig #TODO: rename (git mv) the file instead.
 from .utils import UniformArray
+from wgpu.utils.imgui import ImguiWgpuBackend
+
 
 # could imgui become just another RenderPass after Image? I got to understand backend vs renderer first.
 # make become part of .passes??
@@ -100,3 +103,42 @@ def update_gui():
     # todo: look at exmaples nad largely copy nad paste, will be called in the draw_frame function I think.
 
     pass
+
+
+def gui(constants, constants_data):
+    ig.new_frame()
+    ig.set_next_window_pos((0, 0), ig.Cond_.appearing)
+    ig.set_next_window_size((400, 0), ig.Cond_.appearing)
+    ig.begin("Shader constants", None)
+
+    ig.text('in-dev imgui overlay\n')
+    if ig.is_item_hovered():
+        ig.set_tooltip("TODO")
+
+    # create the sliders?
+    for const in constants:
+        li, name, value, dtype = const
+        if dtype == "f":
+            _, constants_data[name] = ig.slider_float(name, constants_data[name], 0, (value//10)+1.0)
+        elif dtype == "I":
+            _, constants_data[name] = ig.slider_int(name, constants_data[name], 0, (value//10)+1)
+
+    ig.end()
+    ig.end_frame()
+    ig.render()
+    return ig.get_draw_data()
+
+def get_backend(device, canvas, render_texture_format):
+    """
+    copied from backend example, held here to avoid clutter in the main class
+    """
+
+    # init imgui backend
+    ig.create_context()
+    imgui_backend = ImguiWgpuBackend(device, render_texture_format)
+    imgui_backend.io.display_size = canvas.get_logical_size()
+    imgui_backend.io.display_framebuffer_scale = (
+        canvas.get_pixel_ratio(),
+        canvas.get_pixel_ratio(),
+    )
+    return imgui_backend

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -39,6 +39,7 @@ def parse_constants(code:str, common_code) -> list[tuple[int, str, int|float, st
             constants.append((li, name, value, dtype)) # what about line to remove?
             print(f"In line {li} found constant: {name} with value: {value} of dtype {dtype}")
 
+    # maybe just named tuple instead of dataclass?
     return constants
 
 def make_uniform(constants) -> UniformArray:
@@ -47,6 +48,11 @@ def make_uniform(constants) -> UniformArray:
         _, name, value, dtype = constant
         arr_data.append(tuple([name, dtype, 1]))
     data = UniformArray(*arr_data)
+
+    # init data
+    for constant in constants:
+        _, name, value, dtype = constant
+        data[name] = value
     
     # TODO:
     # is there issues with padding? (maybe solve in the class)

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -20,6 +20,7 @@ def parse_constants(code:str, common_code) -> list[tuple[int, str, int|float, st
 
     # for multipass shader this might need to be per pass (rpass.value) ?
     # mataches the macro: #define NAME VALUE
+    # TODO there can be characters in numerical literals, such as x and o for hex and octal representation or e for scientific notation
     define_pattern = re.compile(r"#define\s+(\w+)\s+([\d.]+)")
 
     constants = []

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -119,9 +119,10 @@ def gui(constants, constants_data):
     for const in constants:
         li, name, value, dtype = const
         if dtype == "f":
-            _, constants_data[name] = ig.slider_float(name, constants_data[name], 0, (value//10)+1.0)
+            _, constants_data[name] = ig.slider_float(name, constants_data[name], 0, ((value//10)+1.0)*10.0)
         elif dtype == "I":
-            _, constants_data[name] = ig.slider_int(name, constants_data[name], 0, (value//10)+1)
+            _, constants_data[name] = ig.slider_int(name, constants_data[name], 0, ((value//10)+1)*10)
+            # TODO: improve min/max for negatives
 
     ig.end()
     ig.end_frame()

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -1,8 +1,8 @@
 import re
-# from .shadertoy import UniformArray #TODO: likely restructure into a different file for import reasons...
+from .utils import UniformArray
 
 # could imgui become just another RenderPass after Image? I got to understand backend vs renderer first.
-
+# make become part of .passes??
 # todo: raise error if imgui isn't installed (only if this module is required?)
 
 
@@ -25,27 +25,33 @@ def parse_constants(code, common_code):
             name, value = match.groups()
             if "." in value: #value.isdecimal?
                 # TODO: wgsl needs to be more specific (f32 for example?) - but there is no preprocessor anyways...
-                dtype = "float"
+                dtype = "f" #default float (32bit)
                 value = float(value)
             elif value.isdecimal: # value.isalum?
-                dtype = "int"
+                dtype = "I" # "big I (32bit)"
                 value = int(value)
             else:
                 # TODO complexer types?
                 print(f"can't parse type for constant {name} with value {value}, skipping")
                 continue
-            # todo: remove lines here?
+            # todo: remove lines here? (comment out better)
             constants.append((li, name, value, dtype)) # what about line to remove?
             print(f"In line {li} found constant: {name} with value: {value} of dtype {dtype}")
 
     return constants
 
 def make_uniform(constants):
+    arr_data = []
+    for constant in constants:
+        _, name, value, dtype = constant
+        arr_data.append(tuple([name, dtype, 1]))
+    data = UniformArray(*arr_data)
+    
     # todo:
     # figure out order due to padding/alignment: https://www.w3.org/TR/WGSL/#alignment-and-size
     # return a UniformArray object (cycling import?)
     # (does this need to be a class to update the values?)
-    pass
+    return data
 
 def make_import(uniform) -> str:
     # codegen the import block for this uniform (including binding? - which number?)
@@ -53,6 +59,8 @@ def make_import(uniform) -> str:
     # to be pasted near the top of the fragment shader code.
     # alternatively: insert these in the ShadertoyInputs uniform?
     # better yet: use push constants
+    # TODO: can you even import a uniform struct and then have these available as global?
+    # maybe I got to add them back in as #define name = constant.name or something
 
     pass
 

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -6,7 +6,7 @@ from .utils import UniformArray
 # todo: raise error if imgui isn't installed (only if this module is required?)
 
 
-def parse_constants(code, common_code):
+def parse_constants(code:str, common_code) -> list[tuple[int, str, int|float, str]]:
     # todo:
     # WGSL variants??
     # re/tree-sitter/loops and functions?
@@ -14,7 +14,8 @@ def parse_constants(code, common_code):
     # get information about the line, the type and it's initial value
     # make up a range (maybe just the order of magnitude + 1 as max and 0 as min (what about negative values?))
     # what is the return type? (line(int), type(str), value(float/tuple/int?)) maybe proper dataclasss for once
-    
+
+    # for multipass shader this might need to be per pass (rpass.value) ?
     # mataches the macro: #define NAME VALUE
     define_pattern = re.compile(r"#define\s+(\w+)\s+(.+)")
 
@@ -40,20 +41,21 @@ def parse_constants(code, common_code):
 
     return constants
 
-def make_uniform(constants):
+def make_uniform(constants) -> UniformArray:
     arr_data = []
     for constant in constants:
         _, name, value, dtype = constant
         arr_data.append(tuple([name, dtype, 1]))
     data = UniformArray(*arr_data)
     
-    # todo:
+    # TODO:
+    # is there issues with padding? (maybe solve in the class)
     # figure out order due to padding/alignment: https://www.w3.org/TR/WGSL/#alignment-and-size
     # return a UniformArray object (cycling import?)
     # (does this need to be a class to update the values?)
     return data
 
-def make_import(uniform) -> str:
+def construct_imports(constants, constant_binding_idx=10) -> str:
     # codegen the import block for this uniform (including binding? - which number?)
     # could be part of the UniformArray class maybe?
     # to be pasted near the top of the fragment shader code.
@@ -61,8 +63,30 @@ def make_import(uniform) -> str:
     # better yet: use push constants
     # TODO: can you even import a uniform struct and then have these available as global?
     # maybe I got to add them back in as #define name = constant.name or something
+    var_init_lines = []
+    var_mapping_lines = []
+    for const in constants:
+        _, name, value, dtype = const
+        # TODO: refactor to dtype map or something more useful -.-
+        if dtype == "f":
+            dtype = "float"
+        elif dtype == "I":
+            dtype = "int"
+        else:
+            # shouldn't happen
+            continue
+        var_init_lines.append(f"{dtype} {name};")
+        var_mapping_lines.append(f"# define {name} const_input.{name}")
 
-    pass
+    code_construct = f"""
+    uniform struct ConstantInput {{
+        {'\n'.join(var_init_lines)}
+    }};
+    layout(binding = {constant_binding_idx}) uniform ConstantInput const_input;
+    {"\n".join(var_mapping_lines)}
+    """
+    # TODO messed up indentation...
+    return code_construct
 
 
 # imgui stuff

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -1,4 +1,5 @@
 import re
+# from .shadertoy import UniformArray #TODO: likely restructure into a different file for import reasons...
 
 # could imgui become just another RenderPass after Image? I got to understand backend vs renderer first.
 
@@ -18,12 +19,24 @@ def parse_constants(code, common_code):
     define_pattern = re.compile(r"#define\s+(\w+)\s+(.+)")
 
     constants = []
-    for line in code.splitlines():
+    for li, line in enumerate(code.splitlines()):
         match = define_pattern.match(line.rstrip())
         if match:
-            constants.append(match.groups())
             name, value = match.groups()
-            print(f"Found constant: {name} with value: {value}")
+            if "." in value: #value.isdecimal?
+                # TODO: wgsl needs to be more specific (f32 for example?) - but there is no preprocessor anyways...
+                dtype = "float"
+                value = float(value)
+            elif value.isdecimal: # value.isalum?
+                dtype = "int"
+                value = int(value)
+            else:
+                # TODO complexer types?
+                print(f"can't parse type for constant {name} with value {value}, skipping")
+                continue
+            # todo: remove lines here?
+            constants.append((li, name, value, dtype)) # what about line to remove?
+            print(f"In line {li} found constant: {name} with value: {value} of dtype {dtype}")
 
     return constants
 
@@ -33,6 +46,16 @@ def make_uniform(constants):
     # return a UniformArray object (cycling import?)
     # (does this need to be a class to update the values?)
     pass
+
+def make_import(uniform) -> str:
+    # codegen the import block for this uniform (including binding? - which number?)
+    # could be part of the UniformArray class maybe?
+    # to be pasted near the top of the fragment shader code.
+    # alternatively: insert these in the ShadertoyInputs uniform?
+    # better yet: use push constants
+
+    pass
+
 
 # imgui stuff
 def update_gui():

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -20,7 +20,7 @@ def parse_constants(code:str, common_code) -> list[tuple[int, str, int|float, st
 
     # for multipass shader this might need to be per pass (rpass.value) ?
     # mataches the macro: #define NAME VALUE
-    define_pattern = re.compile(r"#define\s+(\w+)\s+(.+)")
+    define_pattern = re.compile(r"#define\s+(\w+)\s+([\d.]+)")
 
     constants = []
     for li, line in enumerate(code.splitlines()):
@@ -119,9 +119,9 @@ def gui(constants, constants_data):
     for const in constants:
         li, name, value, dtype = const
         if dtype == "f":
-            _, constants_data[name] = ig.slider_float(name, constants_data[name], 0, ((value//10)+1.0)*10.0)
+            _, constants_data[name] = ig.slider_float(name, constants_data[name], 0, value*2.0)
         elif dtype == "I":
-            _, constants_data[name] = ig.slider_int(name, constants_data[name], 0, ((value//10)+1)*10)
+            _, constants_data[name] = ig.slider_int(name, constants_data[name], 0, value*2)
             # TODO: improve min/max for negatives
 
     ig.end()

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -33,7 +33,7 @@ class ShaderConstant:
         # add more types as needed
         return "?"
 
-def parse_constants(code:str, common_code) -> list[ShaderConstant]:
+def parse_constants(code:str) -> list[ShaderConstant]:
     # todo:
     # WGSL variants??
     # re/tree-sitter/loops and functions?
@@ -82,7 +82,7 @@ def parse_constants(code:str, common_code) -> list[ShaderConstant]:
             )
             # todo: remove lines here? (comment out better)
             constants.append(constant)
-            print(f"In line {li} found constant: {name} with value: {value} of dtype {dtype}")
+            print(f"In line {li} found constant: {name} with value: {value} of dtype {dtype}") # maybe name renderpass too?
 
     # maybe just named tuple instead of dataclass?
     return constants
@@ -100,10 +100,11 @@ def make_uniform(constants) -> UniformArray:
     # TODO:
     # is there issues with padding? (maybe solve in the class)
     # figure out order due to padding/alignment: https://www.w3.org/TR/WGSL/#alignment-and-size
-    # return a UniformArray object (cycling import?)
+    # return a UniformArray object too (cycling import?) also needs device handed down.
     # (does this need to be a class to update the values?)
     return data
 
+# TODO mark private?
 def construct_imports(constants: list[ShaderConstant], constant_binding_idx: int) -> str:
     # codegen the import block for this uniform (including binding? - which number?)
     # could be part of the UniformArray class maybe?
@@ -120,18 +121,33 @@ def construct_imports(constants: list[ShaderConstant], constant_binding_idx: int
     var_mapping_lines = []
     for const in constants:
         var_init_lines.append(f"{const.shader_dtype} {const.name};")
-        var_mapping_lines.append(f"# define {const.name} const_input.{const.name}")
+        var_mapping_lines.append(f"# define {const.name} const_input{constant_binding_idx}.{const.name}")
 
     new_line = "\n" # pytest was complaining about having blackslash in an f-string
     code_construct = f"""
-    uniform struct ConstantInput {{
+    uniform struct ConstantInput{constant_binding_idx} {{
         {new_line.join(var_init_lines)}
     }};
-    layout(binding = {constant_binding_idx}) uniform ConstantInput const_input;
+    layout(binding = {constant_binding_idx}) uniform ConstantInput{constant_binding_idx} const_input{constant_binding_idx};
     {new_line.join(var_mapping_lines)}
     """
-    # TODO messed up indentation...
+    # the identifier name includes the digit so common doesn't cause redefinition!
+    # TODO messed up indentation... textwrap.dedent?
     return code_construct
+
+def replace_constants(code: str, constants: list[ShaderConstant], constant_binding_idx: int) -> str:
+    """
+    comment out existing constants and redefine them with uniform struct
+    """
+    code_lines = code.splitlines()
+    for const in constants:
+        # comment out existing constants
+        code_lines[const.line_number] = f"// {code_lines[const.line_number]}"
+
+    constant_headers = construct_imports(constants, constant_binding_idx)
+    code_lines.insert(0, constant_headers)
+
+    return "\n".join(code_lines)
 
 
 # imgui stuff
@@ -144,12 +160,28 @@ def update_gui():
 def gui(renderpasses: list["RenderPass"]):
     ig.new_frame()
     ig.set_next_window_pos((0, 0), ig.Cond_.appearing)
-    ig.set_next_window_size((0, 0), ig.Cond_.appearing)
+    ig.set_next_window_size((0, 0), ig.Cond_.appearing) # auto size not wide enough with text :/
     ig.begin("Shader constants", None)
     ig.text('in-dev imgui overlay\n')
 
     if ig.is_item_hovered():
         ig.set_tooltip("TODO")
+
+    # maybe we should have a global main or utils.get_main()?
+    main = renderpasses[0].main
+
+    # TODO: avoid duplication, maybe common should be a renderpass instance (at least a little bit) - or we iterate through constants lists
+    if main._common_constants:
+        if ig.collapsing_header("Common Constants", flags=ig.TreeNodeFlags_.default_open):
+            for const in main._common_constants:
+                if const.shader_dtype == "float":
+                    _, main._common_constants_data[const.name] = ig.slider_float(f"{const.name}", main._common_constants_data[const.name], -const.value, const.value*2.0)
+                elif const.shader_dtype == "int":
+                    _, main._common_constants_data[const.name] = ig.slider_int(f"{const.name}", main._common_constants_data[const.name], -const.value, const.value*2)
+                if ig.is_item_hovered() and ig.is_mouse_clicked(ig.MouseButton_.right):
+                    main._common_constants_data[const.name] = const.value
+                if ig.is_item_hovered():
+                    ig.set_tooltip("Right click to reset")
 
     for rp in renderpasses: # TODO: most likely add common here?
         constants = rp._constants
@@ -160,6 +192,7 @@ def gui(renderpasses: list["RenderPass"]):
                 front_view = rp.texture_front.create_view()
                 front_ref = rp.main._imgui_backend.register_texture(front_view)
                 scale = 0.25  # TODO dynamic zoom via width?
+                # TODO: can we force a background? do we need to request additional view formats? -> ig.image_with_bg?
                 buf_img = ig.image(front_ref, (front_view.size[0]*scale, front_view.size[1]*scale), uv0=(0,1), uv1=(1,0))
 
             # create the sliders?
@@ -168,7 +201,7 @@ def gui(renderpasses: list["RenderPass"]):
                     _, constants_data[const.name] = ig.slider_float(f"{const.name}", constants_data[const.name], -const.value, const.value*2.0)
                 elif const.shader_dtype == "int":
                     _, constants_data[const.name] = ig.slider_int(f"{const.name}", constants_data[const.name], -const.value, const.value*2)
-                    # TODO: improve min/max for negatives
+                    # TODO: improve min/max for negatives maybe infinite range with scaling?
                 # right click to reset?
                 if ig.is_item_hovered() and ig.is_mouse_clicked(ig.MouseButton_.right):
                     constants_data[const.name] = const.value

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -159,18 +159,24 @@ def gui(renderpasses: list["RenderPass"]):
                 # make this another toggle? or a whole 2nd UI?
                 front_view = rp.texture_front.create_view()
                 front_ref = rp.main._imgui_backend.register_texture(front_view)
-                buf_img = ig.image(front_ref, (front_view.size[0]*0.25, front_view.size[1]*0.25), uv0=(0,1), uv1=(1,0)) # TODO dynamic zoom via width?
+                scale = 0.25  # TODO dynamic zoom via width?
+                buf_img = ig.image(front_ref, (front_view.size[0]*scale, front_view.size[1]*scale), uv0=(0,1), uv1=(1,0))
 
             # create the sliders?
-            # TODO: can we reset the values with a button or a double click maybe?
             for const in constants:
                 if const.shader_dtype == "float":
                     _, constants_data[const.name] = ig.slider_float(f"{const.name}", constants_data[const.name], -const.value, const.value*2.0)
                 elif const.shader_dtype == "int":
                     _, constants_data[const.name] = ig.slider_int(f"{const.name}", constants_data[const.name], -const.value, const.value*2)
                     # TODO: improve min/max for negatives
-    # TODO: control the size of these headers to make the window as small as possible after they are collapsed!
+                # right click to reset?
+                if ig.is_item_hovered() and ig.is_mouse_clicked(ig.MouseButton_.right):
+                    constants_data[const.name] = const.value
+                    # print(f"Reset {const.name} to {const.value} from {constants_data[const.name]}")
+                if ig.is_item_hovered():
+                    ig.set_tooltip("Right click to reset")
 
+    # TODO: control the size of these headers to make the window as small as possible after they are collapsed!
     ig.end()
     ig.end_frame()
     ig.render()

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -112,6 +112,10 @@ def construct_imports(constants: list[ShaderConstant], constant_binding_idx: int
     # better yet: use push constants
     # TODO: can you even import a uniform struct and then have these available as global?
     # maybe I got to add them back in as #define name = constant.name or something
+
+    if not constants:
+        return ""
+
     var_init_lines = []
     var_mapping_lines = []
     for const in constants:

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -5,6 +5,7 @@ from .utils import UniformArray
 from wgpu.utils.imgui import ImguiWgpuBackend
 # from wgpu_shadertoy.passes import RenderPass #circular import-.-
 from dataclasses import dataclass
+from math import log
 
 
 # could imgui become just another RenderPass after Image? I got to understand backend vs renderer first.
@@ -175,13 +176,11 @@ def gui(renderpasses: list["RenderPass"]):
         if ig.collapsing_header("Common Constants", flags=ig.TreeNodeFlags_.default_open):
             for const in main._common_constants:
                 if const.shader_dtype == "float":
-                    _, main._common_constants_data[const.name] = ig.slider_float(f"{const.name}", main._common_constants_data[const.name], -const.value, const.value*2.0)
+                    _, main._common_constants_data[const.name] = ig.drag_float(f"{const.name}", main._common_constants_data[const.name], v_speed=abs(const.value)*0.01)
                 elif const.shader_dtype == "int":
-                    _, main._common_constants_data[const.name] = ig.slider_int(f"{const.name}", main._common_constants_data[const.name], -const.value, const.value*2)
+                    _, main._common_constants_data[const.name] = ig.drag_int(f"{const.name}", main._common_constants_data[const.name], v_speed=abs(const.value)*0.01)
                 if ig.is_item_hovered() and ig.is_mouse_clicked(ig.MouseButton_.right):
                     main._common_constants_data[const.name] = const.value
-                if ig.is_item_hovered():
-                    ig.set_tooltip("Right click to reset")
 
     for rp in renderpasses: # TODO: most likely add common here?
         constants = rp._constants
@@ -195,19 +194,16 @@ def gui(renderpasses: list["RenderPass"]):
                 # TODO: can we force a background? do we need to request additional view formats? -> ig.image_with_bg?
                 buf_img = ig.image(front_ref, (front_view.size[0]*scale, front_view.size[1]*scale), uv0=(0,1), uv1=(1,0))
 
-            # create the sliders?
+            # create the sliders? -> drag widget!
             for const in constants:
                 if const.shader_dtype == "float":
-                    _, constants_data[const.name] = ig.slider_float(f"{const.name}", constants_data[const.name], -const.value, const.value*2.0)
+                    _, constants_data[const.name] = ig.drag_float(f"{const.name}", constants_data[const.name], v_speed=abs(const.value)*0.01)
                 elif const.shader_dtype == "int":
-                    _, constants_data[const.name] = ig.slider_int(f"{const.name}", constants_data[const.name], -const.value, const.value*2)
-                    # TODO: improve min/max for negatives maybe infinite range with scaling?
-                # right click to reset?
+                    _, constants_data[const.name] = ig.drag_int(f"{const.name}", constants_data[const.name], v_speed=abs(const.value)*0.01)
                 if ig.is_item_hovered() and ig.is_mouse_clicked(ig.MouseButton_.right):
                     constants_data[const.name] = const.value
-                    # print(f"Reset {const.name} to {const.value} from {constants_data[const.name]}")
-                if ig.is_item_hovered():
-                    ig.set_tooltip("Right click to reset")
+                    
+    ig.text("Right sliders/drag to reset")
 
     # TODO: control the size of these headers to make the window as small as possible after they are collapsed!
     ig.end()

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -146,11 +146,12 @@ def gui(constants: list[ShaderConstant], constants_data: UniformArray):
         ig.set_tooltip("TODO")
 
     # create the sliders?
+    # TODO: can we reset the values with a button or a double click maybe?
     for const in constants:
         if const.shader_dtype == "float":
-            _, constants_data[const.name] = ig.slider_float(const.name, constants_data[const.name], 0, const.value*2.0)
+            _, constants_data[const.name] = ig.slider_float(const.name, constants_data[const.name], -const.value, const.value*2.0)
         elif const.shader_dtype == "int":
-            _, constants_data[const.name] = ig.slider_int(const.name, constants_data[const.name], 0, const.value*2)
+            _, constants_data[const.name] = ig.slider_int(const.name, constants_data[const.name], -const.value, const.value*2)
             # TODO: improve min/max for negatives
 
     ig.end()

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -144,7 +144,7 @@ def update_gui():
 def gui(renderpasses: list["RenderPass"]):
     ig.new_frame()
     ig.set_next_window_pos((0, 0), ig.Cond_.appearing)
-    ig.set_next_window_size((400, 0), ig.Cond_.appearing)
+    ig.set_next_window_size((0, 0), ig.Cond_.appearing)
     ig.begin("Shader constants", None)
     ig.text('in-dev imgui overlay\n')
 
@@ -169,7 +169,6 @@ def gui(renderpasses: list["RenderPass"]):
                 elif const.shader_dtype == "int":
                     _, constants_data[const.name] = ig.slider_int(f"{const.name}", constants_data[const.name], -const.value, const.value*2)
                     # TODO: improve min/max for negatives
-    
     # TODO: control the size of these headers to make the window as small as possible after they are collapsed!
 
     ig.end()

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -155,6 +155,12 @@ def gui(renderpasses: list["RenderPass"]):
         constants = rp._constants
         constants_data = rp._constants_data
         if ig.collapsing_header(f"{rp} Constants", flags=ig.TreeNodeFlags_.default_open):
+            if hasattr(rp, "texture_front"): # isinstance(rp, BufferRenderPass)
+                # make this another toggle? or a whole 2nd UI?
+                front_view = rp.texture_front.create_view()
+                front_ref = rp.main._imgui_backend.register_texture(front_view)
+                buf_img = ig.image(front_ref, (front_view.size[0]*0.25, front_view.size[1]*0.25), uv0=(0,1), uv1=(1,0)) # TODO dynamic zoom via width?
+
             # create the sliders?
             # TODO: can we reset the values with a button or a double click maybe?
             for const in constants:

--- a/wgpu_shadertoy/imgui.py
+++ b/wgpu_shadertoy/imgui.py
@@ -1,7 +1,9 @@
 import re
-from imgui_bundle import imgui as ig #TODO: rename (git mv) the file instead.
+from imgui_bundle import imgui as ig
+
 from .utils import UniformArray
 from wgpu.utils.imgui import ImguiWgpuBackend
+# from wgpu_shadertoy.passes import RenderPass #circular import-.-
 from dataclasses import dataclass
 
 
@@ -12,7 +14,7 @@ from dataclasses import dataclass
 
 @dataclass
 class ShaderConstant:
-    renderpass_pass: str #maybe this is a RenderPass pointer?
+    # renderpass_pass: str #maybe this is a RenderPass pointer? likely redundant
     line_number: int
     original_line: str
     name: str
@@ -44,7 +46,7 @@ def parse_constants(code:str, common_code) -> list[ShaderConstant]:
     # mataches the macro: #define NAME VALUE
     # TODO there can be characters in numerical literals, such as x and o for hex and octal representation or e for scientific notation
     # technically the macros can also be an expression that is evaluated to be a number... such as # define DOF 10..0/30.0 - so how do we deal with that?
-    define_pattern = re.compile(r"#\s*define\s+(\w+)\s+([\d.]+)") #for numerical literals right now.
+    define_pattern = re.compile(r"#\s*define\s+(\w+)\s+(-?[\d.]+)") #for numerical literals right now.
     if_def_template = r"#(el)?if\s+" #preprocessor ifdef blocks can't become uniforms. replacing these dynamically will be difficult.
 
     constants = []
@@ -71,7 +73,7 @@ def parse_constants(code:str, common_code) -> list[ShaderConstant]:
                 continue
 
             constant = ShaderConstant(
-                renderpass_pass="image",  # TODO: shouldn't be names.
+                # renderpass_pass="image",  # TODO: shouldn't be names.
                 line_number=li,
                 original_line=line.strip(),
                 name=name,
@@ -102,7 +104,7 @@ def make_uniform(constants) -> UniformArray:
     # (does this need to be a class to update the values?)
     return data
 
-def construct_imports(constants: list[ShaderConstant], constant_binding_idx=10) -> str:
+def construct_imports(constants: list[ShaderConstant], constant_binding_idx: int) -> str:
     # codegen the import block for this uniform (including binding? - which number?)
     # could be part of the UniformArray class maybe?
     # to be pasted near the top of the fragment shader code.
@@ -135,24 +137,30 @@ def update_gui():
     pass
 
 
-def gui(constants: list[ShaderConstant], constants_data: UniformArray):
+def gui(renderpasses: list["RenderPass"]):
     ig.new_frame()
     ig.set_next_window_pos((0, 0), ig.Cond_.appearing)
     ig.set_next_window_size((400, 0), ig.Cond_.appearing)
     ig.begin("Shader constants", None)
-
     ig.text('in-dev imgui overlay\n')
+
     if ig.is_item_hovered():
         ig.set_tooltip("TODO")
 
-    # create the sliders?
-    # TODO: can we reset the values with a button or a double click maybe?
-    for const in constants:
-        if const.shader_dtype == "float":
-            _, constants_data[const.name] = ig.slider_float(const.name, constants_data[const.name], -const.value, const.value*2.0)
-        elif const.shader_dtype == "int":
-            _, constants_data[const.name] = ig.slider_int(const.name, constants_data[const.name], -const.value, const.value*2)
-            # TODO: improve min/max for negatives
+    for rp in renderpasses: # TODO: most likely add common here?
+        constants = rp._constants
+        constants_data = rp._constants_data
+        if ig.collapsing_header(f"{rp} Constants", flags=ig.TreeNodeFlags_.default_open):
+            # create the sliders?
+            # TODO: can we reset the values with a button or a double click maybe?
+            for const in constants:
+                if const.shader_dtype == "float":
+                    _, constants_data[const.name] = ig.slider_float(f"{const.name}", constants_data[const.name], -const.value, const.value*2.0)
+                elif const.shader_dtype == "int":
+                    _, constants_data[const.name] = ig.slider_int(f"{const.name}", constants_data[const.name], -const.value, const.value*2)
+                    # TODO: improve min/max for negatives
+    
+    # TODO: control the size of these headers to make the window as small as possible after they are collapsed!
 
     ig.end()
     ig.end_frame()

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -4,7 +4,7 @@ from typing import List
 import wgpu
 
 from .inputs import ShadertoyChannel, ShadertoyChannelBuffer, ShadertoyChannelTexture
-from .imgui import construct_imports
+from .imgui import construct_imports, gui
 
 builtin_variables_glsl = """#version 450 core
 
@@ -323,8 +323,14 @@ class RenderPass:
         # self._bind_group might get generalized out for buffer
         render_pass.set_bind_group(0, self._bind_group, [], 0, 99)
         render_pass.draw(3, 1, 0, 0)
-        render_pass.end()
 
+        if self.main._imgui:
+            psize = self.main._canvas.get_physical_size()
+            # TODO: refactor as this only needs to happen in the main class? maybe I can get the .end and .finish externally...
+            imgui_data = gui(self.main._constants, self.main._constants_data)
+            self.main._imgui_backend.render(imgui_data, render_pass, psize)
+
+        render_pass.end()
         return command_encoder.finish()
 
     def construct_code(self) -> tuple[str, str]:

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -387,8 +387,7 @@ class RenderPass:
                 # comment out existing constants
                 shader_code_lines = self.shader_code.splitlines()
                 for const in self.main._constants:
-                    line_number = const[0]
-                    shader_code_lines[line_number] = "// " + shader_code_lines[line_number]
+                    shader_code_lines[const.line_number] = "// " + shader_code_lines[const.line_number]
                 self._shader_code = "\n".join(shader_code_lines)
 
                 constant_headers = construct_imports(self.main._constants)

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -203,6 +203,25 @@ class RenderPass:
             },
         ]
 
+        if self.main._imgui:
+            bind_groups_layout_entries.append(
+                {
+                    "binding": 10,
+                    "resource": {
+                        "buffer": self.main._constants_buffer,
+                        "offset": 0,
+                        "size": self.main._constants_buffer.size,
+                    },
+                },
+            )
+            binding_layout.append(
+                {
+                    "binding": 10,
+                    "visibility": wgpu.ShaderStage.FRAGMENT,
+                    "buffer": {"type": wgpu.BufferBindingType.uniform},
+                },
+            )
+
         # setup bind groups for the channels
         channel_res = []
         for channel in self.channels:

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -325,10 +325,9 @@ class RenderPass:
         render_pass.draw(3, 1, 0, 0)
 
         if self.main._imgui:
-            psize = self.main._canvas.get_physical_size()
             # TODO: refactor as this only needs to happen in the main class? maybe I can get the .end and .finish externally...
             imgui_data = gui(self.main._constants, self.main._constants_data)
-            self.main._imgui_backend.render(imgui_data, render_pass, psize)
+            self.main._imgui_backend.render(imgui_data, render_pass)
 
         render_pass.end()
         return command_encoder.finish()

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -367,6 +367,15 @@ class RenderPass:
                     mainImage(FragColor, fragcoord);
                 }}
                 """
+            
+            if self.main._imgui:
+                # comment out existing constants
+                shader_code_lines = self.shader_code.splitlines()
+                for const in self.main._constants:
+                    line_number = const[0]
+                    shader_code_lines[line_number] = "// " + shader_code_lines[line_number]
+                self._shader_code = "\n".join(shader_code_lines)
+
             frag_shader_code = (
                 builtin_variables_glsl
                 + self._input_headers

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -4,7 +4,7 @@ from typing import List
 import wgpu
 
 from .inputs import ShadertoyChannel, ShadertoyChannelBuffer, ShadertoyChannelTexture
-from .imgui import construct_imports, gui
+from .imgui import construct_imports, gui, parse_constants, make_uniform
 
 builtin_variables_glsl = """#version 450 core
 
@@ -56,6 +56,7 @@ class RenderPass:
         # we keep track of the inputs before we can attach them as channels.
         self._inputs = inputs
         self._input_headers = ""
+
 
     def get_current_texture(self) -> wgpu.GPUTexture:
         """
@@ -163,6 +164,18 @@ class RenderPass:
         It attaches inputs, assembles the shadercode and creates the render pipeline.
         """
 
+        # need to be after we got main class?
+        if self.main._imgui:
+            # maybe a self._imgui for the case where there are no local or common constants?
+            self._constants = parse_constants(self.shader_code, self.main.common)
+            self._constants_data = make_uniform(self._constants)
+            self._constants_buffer = self._device.create_buffer(
+                label=f"{self} constant buffer for imgui overlay",
+                size=self._constants_data.nbytes, 
+                usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST
+            )
+            self._constants_binding_idx = 10 + self.main.renderpasses.index(self)
+
         # inputs can only be attached once the main class is set, so calling it here should do it.
         self.channels = self._attach_inputs(self._inputs)
         vertex_shader_code, frag_shader_code = self.construct_code()
@@ -179,6 +192,9 @@ class RenderPass:
             size=self.main._uniform_data.nbytes,
             usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST,
         )
+
+
+
         self._setup_renderpipeline()  # split in half so the next part can be reused.
 
     def _setup_renderpipeline(self):
@@ -207,17 +223,17 @@ class RenderPass:
         if self.main._imgui:
             bind_groups_layout_entries.append(
                 {
-                    "binding": 10,
+                    "binding": self._constants_binding_idx,
                     "resource": {
-                        "buffer": self.main._constants_buffer,
+                        "buffer": self._constants_buffer,
                         "offset": 0,
-                        "size": self.main._constants_buffer.size,
+                        "size": self._constants_buffer.size,
                     },
                 },
             )
             binding_layout.append(
                 {
-                    "binding": 10,
+                    "binding": self._constants_binding_idx,
                     "visibility": wgpu.ShaderStage.FRAGMENT,
                     "buffer": {"type": wgpu.BufferBindingType.uniform},
                 },
@@ -294,11 +310,11 @@ class RenderPass:
 
         if self.main._imgui:
             self._device.queue.write_buffer(
-                buffer = self.main._constants_buffer,
+                buffer = self._constants_buffer,
                 buffer_offset = 0,
-                data = self.main._constants_data.mem,
+                data = self._constants_data.mem,
                 data_offset = 0,
-                size = self.main._constants_buffer.size,
+                size = self._constants_buffer.size,
             )
 
         command_encoder: wgpu.GPUCommandEncoder = self._device.create_command_encoder()
@@ -324,10 +340,12 @@ class RenderPass:
         render_pass.set_bind_group(0, self._bind_group, [], 0, 99)
         render_pass.draw(3, 1, 0, 0)
 
-        if self.main._imgui:
-            # TODO: refactor as this only needs to happen in the main class? maybe I can get the .end and .finish externally...
-            imgui_data = gui(self.main._constants, self.main._constants_data)
-            self.main._imgui_backend.render(imgui_data, render_pass)
+        # instead of reimplementing the same thing twice?
+        if isinstance(self, ImageRenderPass) and self.main._imgui:
+            # render imgui overlay only on the image pass.
+            if self.main._imgui_backend is not None:
+                imgui_data = gui(self._main.renderpasses)
+                self.main._imgui_backend.render(imgui_data, render_pass)
 
         render_pass.end()
         return command_encoder.finish()
@@ -386,11 +404,11 @@ class RenderPass:
             if self.main._imgui:
                 # comment out existing constants
                 shader_code_lines = self.shader_code.splitlines()
-                for const in self.main._constants:
+                for const in self._constants:
                     shader_code_lines[const.line_number] = "// " + shader_code_lines[const.line_number]
                 self._shader_code = "\n".join(shader_code_lines)
 
-                constant_headers = construct_imports(self.main._constants)
+                constant_headers = construct_imports(self._constants, self._constants_binding_idx)
                 # TODO use a new variable instead in the block below!
                 self._shader_code = constant_headers + "\n" + self.shader_code
 

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -220,7 +220,7 @@ class RenderPass:
             },
         ]
 
-        if self.main._imgui:
+        if self.main._imgui and self._constants:
             bind_groups_layout_entries.append(
                 {
                     "binding": self._constants_binding_idx,
@@ -308,7 +308,7 @@ class RenderPass:
             size=self.main._uniform_data.nbytes,
         )
 
-        if self.main._imgui:
+        if self.main._imgui and self._constants:
             self._device.queue.write_buffer(
                 buffer = self._constants_buffer,
                 buffer_offset = 0,

--- a/wgpu_shadertoy/passes.py
+++ b/wgpu_shadertoy/passes.py
@@ -4,7 +4,7 @@ from typing import List
 import wgpu
 
 from .inputs import ShadertoyChannel, ShadertoyChannelBuffer, ShadertoyChannelTexture
-from .imgui import construct_imports, gui, parse_constants, make_uniform
+from .imgui import replace_constants, gui, parse_constants, make_uniform
 
 builtin_variables_glsl = """#version 450 core
 
@@ -167,15 +167,16 @@ class RenderPass:
         # need to be after we got main class?
         if self.main._imgui:
             # maybe a self._imgui for the case where there are no local or common constants?
-            self._constants = parse_constants(self.shader_code, self.main.common)
+            self._constants = parse_constants(self.shader_code)
             self._constants_data = make_uniform(self._constants)
             self._constants_buffer = self._device.create_buffer(
                 label=f"{self} constant buffer for imgui overlay",
                 size=self._constants_data.nbytes, 
                 usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST
             )
-            self._constants_binding_idx = 10 + self.main.renderpasses.index(self)
-
+            # 0 is uniform buffer, 2 per input (texture + sampler), 9 for common constants and finally 10 for pass constants
+            # TODO can there be gaps like this? then we don't need a constant anyway.
+            self._constants_binding_idx = 10
         # inputs can only be attached once the main class is set, so calling it here should do it.
         self.channels = self._attach_inputs(self._inputs)
         vertex_shader_code, frag_shader_code = self.construct_code()
@@ -237,6 +238,26 @@ class RenderPass:
                     "visibility": wgpu.ShaderStage.FRAGMENT,
                     "buffer": {"type": wgpu.BufferBindingType.uniform},
                 },
+            )
+        # TODO: could we make a little iterable at the top? (also doesn't need to be nested?)
+        if self.main._imgui and self.main._common_constants:
+            # # maybe we can one fewer buffers but use the offsets instead?
+            bind_groups_layout_entries.append(
+                {
+                    "binding": 9,
+                    "resource": {
+                        "buffer": self.main._common_constants_buffer,
+                        "offset": 0,
+                        "size": self.main._common_constants_buffer.size,
+                    },
+                }
+            )
+            binding_layout.append(
+                {
+                    "binding": 9,
+                    "visibility": wgpu.ShaderStage.FRAGMENT,
+                    "buffer": {"type": wgpu.BufferBindingType.uniform},
+                }
             )
 
         # setup bind groups for the channels
@@ -316,6 +337,14 @@ class RenderPass:
                 data_offset = 0,
                 size = self._constants_buffer.size,
             )
+        if self.main._imgui and self.main._common_constants:
+            self._device.queue.write_buffer(
+                buffer=self.main._common_constants_buffer,
+                buffer_offset=0,
+                data=self.main._common_constants_data.mem,
+                data_offset=0,
+                size=self.main._common_constants_buffer.size,
+            )
 
         command_encoder: wgpu.GPUCommandEncoder = self._device.create_command_encoder()
         current_texture: wgpu.GPUTexture = self.get_current_texture()
@@ -344,7 +373,7 @@ class RenderPass:
         if isinstance(self, ImageRenderPass) and self.main._imgui:
             # render imgui overlay only on the image pass.
             if self.main._imgui_backend is not None:
-                imgui_data = gui(self._main.renderpasses)
+                imgui_data = gui(self.main.renderpasses)
                 self.main._imgui_backend.render(imgui_data, render_pass)
 
         render_pass.end()
@@ -402,15 +431,7 @@ class RenderPass:
                 """
             
             if self.main._imgui:
-                # comment out existing constants
-                shader_code_lines = self.shader_code.splitlines()
-                for const in self._constants:
-                    shader_code_lines[const.line_number] = "// " + shader_code_lines[const.line_number]
-                self._shader_code = "\n".join(shader_code_lines)
-
-                constant_headers = construct_imports(self._constants, self._constants_binding_idx)
-                # TODO use a new variable instead in the block below!
-                self._shader_code = constant_headers + "\n" + self.shader_code
+                self._shader_code = replace_constants(self._shader_code, self._constants, self._constants_binding_idx)
 
             frag_shader_code = (
                 builtin_variables_glsl

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -1,5 +1,4 @@
 import collections
-import ctypes
 import os
 import time
 
@@ -11,56 +10,7 @@ from rendercanvas.offscreen import loop as run_offscreen
 from .api import shader_args_from_json, shadertoy_from_id
 from .passes import BufferRenderPass, ImageRenderPass, RenderPass
 from .imgui import parse_constants
-
-
-class UniformArray:
-    """Convenience class to create a uniform array.
-
-    Ensure that the order matches structs in the shader code.
-    See https://www.w3.org/TR/WGSL/#alignment-and-size for reference on alignment.
-    """
-
-    def __init__(self, *args):
-        # Analyse incoming fields
-        fields = []
-        byte_offset = 0
-        for name, format, n in args:
-            assert format in ("f", "i", "I")
-            field = name, format, byte_offset, byte_offset + n * 4
-            fields.append(field)
-            byte_offset += n * 4
-        # Get padding
-        nbytes = byte_offset
-        while nbytes % 16:
-            nbytes += 1
-        # Construct memoryview object and a view for each field
-        self._mem = memoryview((ctypes.c_uint8 * nbytes)()).cast("B")
-        self._views = {}
-        for name, format, i1, i2 in fields:
-            self._views[name] = self._mem[i1:i2].cast(format)
-
-    @property
-    def mem(self):
-        return self._mem
-
-    @property
-    def nbytes(self):
-        return self._mem.nbytes
-
-    def __getitem__(self, key):
-        v = self._views[key].tolist()
-        return v[0] if len(v) == 1 else v
-
-    def __setitem__(self, key, val):
-        m = self._views[key]
-        n = m.shape[0]
-        if n == 1:
-            assert isinstance(val, (float, int))
-            m[0] = val
-        else:
-            assert isinstance(val, (tuple, list))
-            for i in range(n):
-                m[i] = val[i]
+from .utils import UniformArray
 
 
 class Shadertoy:

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -8,7 +8,7 @@ from rendercanvas.offscreen import RenderCanvas as OffscreenCanvas
 from rendercanvas.offscreen import loop as run_offscreen
 
 from .api import shader_args_from_json, shadertoy_from_id
-from .imgui import parse_constants, make_uniform
+from .imgui import parse_constants, make_uniform, construct_imports
 from .passes import BufferRenderPass, ImageRenderPass, RenderPass
 from .utils import UniformArray
 
@@ -108,7 +108,9 @@ class Shadertoy:
             device_features.append(wgpu.FeatureName.float32_filterable)
         self._device = self._request_device(device_features)
 
-        if imgui:
+
+        self._imgui = imgui
+        if self._imgui:
             self._constants = parse_constants(shader_code, self.common)
             self._constants_data = make_uniform(self._constants)
             self._constants_buffer = self._device.create_buffer(
@@ -116,7 +118,8 @@ class Shadertoy:
                 size=self._constants_data.nbytes, 
                 usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST
             )
-
+            import_code = construct_imports(self._constants)
+            print(import_code)
 
         self._prepare_canvas(canvas=canvas)
         self._bind_events()

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -8,7 +8,7 @@ from rendercanvas.offscreen import RenderCanvas as OffscreenCanvas
 from rendercanvas.offscreen import loop as run_offscreen
 
 from .api import shader_args_from_json, shadertoy_from_id
-from .imgui import parse_constants, make_uniform, construct_imports
+from .imgui import parse_constants, make_uniform, construct_imports, get_backend
 from .passes import BufferRenderPass, ImageRenderPass, RenderPass
 from .utils import UniformArray
 
@@ -118,8 +118,6 @@ class Shadertoy:
                 size=self._constants_data.nbytes, 
                 usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST
             )
-            import_code = construct_imports(self._constants)
-            print(import_code)
 
         self._prepare_canvas(canvas=canvas)
         self._bind_events()
@@ -224,6 +222,9 @@ class Shadertoy:
         ).removesuffix("-srgb")
 
         self._present_context.configure(device=self._device, format=self._format)
+
+        if self._imgui:
+            self._imgui_backend = get_backend(self._device, self._canvas, self._format)
 
     def _bind_events(self):
         # event spec: https://jupyter-rfb.readthedocs.io/en/stable/events.html

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -10,6 +10,7 @@ from rendercanvas.offscreen import loop as run_offscreen
 
 from .api import shader_args_from_json, shadertoy_from_id
 from .passes import BufferRenderPass, ImageRenderPass, RenderPass
+from .imgui import parse_constants
 
 
 class UniformArray:
@@ -77,6 +78,7 @@ class Shadertoy:
         title (str): The title of the window. Defaults to "Shadertoy".
         complete (bool): Whether the shader is complete. Unsupported renderpasses or inputs will set this to False. Default is True.
         canvas (RenderCanvas): Optionally provide the canvas the image pass will render too. Defaults to None (means auto?)
+        imgui (bool): Automatiicaly parse constants and provide a imgui interface to change them. Default is False.
 
     The shader code must contain a entry point function:
 
@@ -114,6 +116,7 @@ class Shadertoy:
         title: str = "Shadertoy",
         complete: bool = True,
         canvas=None,
+        imgui: bool = False,
     ) -> None:
         self._uniform_data = UniformArray(
             ("mouse", "f", 4),
@@ -149,6 +152,9 @@ class Shadertoy:
             self.title += " (incomplete)"
 
         self.title += " $fps FPS"
+
+        if imgui:
+            self._constants = parse_constants(shader_code, self.common)
 
         device_features = []
         if buffers:

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -237,7 +237,7 @@ class Shadertoy:
                 # render loop is suspended during any window interaction anyway - will be fixed with rendercanvas: https://github.com/pygfx/rendercanvas/issues/69
                 buf.resize_buffer()
             if self._imgui:
-                self._imgui_backend.io.display_size(w,h)
+                self._imgui_backend.io.display_size = (w,h)
 
         def on_mouse_move(event):
             if event["button"] == 1 or 1 in event["buttons"]:

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -236,6 +236,8 @@ class Shadertoy:
                 # TODO: do we want to call this every single time or only when the resize is done?
                 # render loop is suspended during any window interaction anyway - will be fixed with rendercanvas: https://github.com/pygfx/rendercanvas/issues/69
                 buf.resize_buffer()
+            if self._imgui:
+                self._imgui_backend.io.display_size(w,h)
 
         def on_mouse_move(event):
             if event["button"] == 1 or 1 in event["buttons"]:
@@ -243,6 +245,8 @@ class Shadertoy:
                 ratio = self._uniform_data["resolution"][2]
                 x1, y1 = event["x"] * ratio, self.resolution[1] - event["y"] * ratio
                 self._uniform_data["mouse"] = x1, y1, abs(x2), -abs(y2)
+            if self._imgui:
+                self._imgui_backend.io.add_mouse_pos_event(event["x"], event["y"])
 
         def on_mouse_down(event):
             if event["button"] == 1 or 1 in event["buttons"]:
@@ -255,10 +259,17 @@ class Shadertoy:
                 x1, y1, x2, y2 = self._uniform_data["mouse"]
                 self._uniform_data["mouse"] = x1, y1, -abs(x2), -abs(y2)
 
+        def on_mouse(event):
+            event_type = event["event_type"]
+            down = event_type == "pointer_down"
+            if self._imgui:
+                self._imgui_backend.io.add_mouse_button_event(event["button"] - 1, down)
+
         self._canvas.add_event_handler(on_resize, "resize")
         self._canvas.add_event_handler(on_mouse_move, "pointer_move")
         self._canvas.add_event_handler(on_mouse_down, "pointer_down")
         self._canvas.add_event_handler(on_mouse_up, "pointer_up")
+        self._canvas.add_event_handler(on_mouse, "pointer_up", "pointer_down")
 
     def _update(self):
         now = time.perf_counter()

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -246,6 +246,7 @@ class Shadertoy:
                 x1, y1 = event["x"] * ratio, self.resolution[1] - event["y"] * ratio
                 self._uniform_data["mouse"] = x1, y1, abs(x2), -abs(y2)
             if self._imgui:
+                # TODO: we should ignore mouse updates when moving imgui sliders.
                 self._imgui_backend.io.add_mouse_pos_event(event["x"], event["y"])
 
         def on_mouse_down(event):
@@ -330,6 +331,13 @@ class Shadertoy:
             run_offscreen.run()
         else:
             loop.run()
+            if self._imgui:
+                for constant in self._constants:
+                    # TODO: this check messes up due to precision sometimes!
+                    if constant.value != self._constants_data[constant.name]:
+                        print(
+                            f"Constant {constant.shader_dtype} {constant.name}: {constant.value} -> {self._constants_data[constant.name]}"
+                        )
 
     def snapshot(
         self,

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -110,14 +110,7 @@ class Shadertoy:
 
 
         self._imgui = imgui
-        if self._imgui:
-            self._constants = parse_constants(shader_code, self.common)
-            self._constants_data = make_uniform(self._constants)
-            self._constants_buffer = self._device.create_buffer(
-                label="constant buffer for imgui overlay",
-                size=self._constants_data.nbytes, 
-                usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST
-            )
+        
 
         self._prepare_canvas(canvas=canvas)
         self._bind_events()

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -325,12 +325,13 @@ class Shadertoy:
         else:
             loop.run()
             if self._imgui:
-                for constant in self._constants:
-                    # TODO: this check messes up due to precision sometimes!
-                    if constant.value != self._constants_data[constant.name]:
-                        print(
-                            f"Constant {constant.shader_dtype} {constant.name}: {constant.value} -> {self._constants_data[constant.name]}"
-                        )
+                for rp in self.renderpasses:
+                    for constant in rp._constants:
+                        # TODO: this check messes up due to precision sometimes!
+                        if constant.value != rp._constants_data[constant.name]:
+                            print(
+                                f"{rp} Constant {constant.shader_dtype} {constant.name}: {constant.value} -> {rp._constants_data[constant.name]}"
+                            )
 
     def snapshot(
         self,

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -8,7 +8,7 @@ from rendercanvas.offscreen import RenderCanvas as OffscreenCanvas
 from rendercanvas.offscreen import loop as run_offscreen
 
 from .api import shader_args_from_json, shadertoy_from_id
-from .imgui import parse_constants, make_uniform, construct_imports, get_backend
+from .imgui import parse_constants, make_uniform, replace_constants, get_backend
 from .passes import BufferRenderPass, ImageRenderPass, RenderPass
 from .utils import UniformArray
 
@@ -110,7 +110,18 @@ class Shadertoy:
 
 
         self._imgui = imgui
-        
+        if self._imgui:
+            self._common_constants = parse_constants(self.common)
+            if self._common_constants:
+                self._common_constants_data = make_uniform(self._common_constants)
+                self._common_constants_buffer = self._device.create_buffer(
+                    label="Common constants buffer",
+                    size=self._common_constants_data.nbytes,
+                    usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST,
+                )
+                self.common = replace_constants(self.common, self._common_constants, 9)
+            # else not have this at all?
+
 
         self._prepare_canvas(canvas=canvas)
         self._bind_events()

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -233,17 +233,16 @@ class Shadertoy:
                 self._imgui_backend.io.display_size = (w,h)
 
         def on_mouse_move(event):
-            if event["button"] == 1 or 1 in event["buttons"]:
+            if (event["button"] == 1 or 1 in event["buttons"]) and not (self._imgui and self._imgui_backend.io.want_capture_mouse):
                 _, _, x2, y2 = self._uniform_data["mouse"]
                 ratio = self._uniform_data["resolution"][2]
                 x1, y1 = event["x"] * ratio, self.resolution[1] - event["y"] * ratio
                 self._uniform_data["mouse"] = x1, y1, abs(x2), -abs(y2)
             if self._imgui:
-                # TODO: we should ignore mouse updates when moving imgui sliders.
                 self._imgui_backend.io.add_mouse_pos_event(event["x"], event["y"])
 
         def on_mouse_down(event):
-            if event["button"] == 1 or 1 in event["buttons"]:
+            if (event["button"] == 1 or 1 in event["buttons"]) and not (self._imgui and self._imgui_backend.io.want_capture_mouse):
                 ratio = self._uniform_data["resolution"][2]
                 x, y = event["x"] * ratio, self.resolution[1] - event["y"] * ratio
                 self._uniform_data["mouse"] = (x, y, abs(x), abs(y))

--- a/wgpu_shadertoy/utils.py
+++ b/wgpu_shadertoy/utils.py
@@ -10,6 +10,9 @@ class UniformArray:
     """
 
     def __init__(self, *args):
+        """
+        *args is an iterable with (name, format, dim)
+        """
         # Analyse incoming fields
         fields = []
         byte_offset = 0

--- a/wgpu_shadertoy/utils.py
+++ b/wgpu_shadertoy/utils.py
@@ -1,0 +1,52 @@
+import ctypes
+
+# Helper classes to be used throughout the project
+
+class UniformArray:
+    """Convenience class to create a uniform array.
+
+    Ensure that the order matches structs in the shader code.
+    See https://www.w3.org/TR/WGSL/#alignment-and-size for reference on alignment.
+    """
+
+    def __init__(self, *args):
+        # Analyse incoming fields
+        fields = []
+        byte_offset = 0
+        for name, format, n in args:
+            assert format in ("f", "i", "I")
+            field = name, format, byte_offset, byte_offset + n * 4
+            fields.append(field)
+            byte_offset += n * 4
+        # Get padding
+        nbytes = byte_offset
+        while nbytes % 16:
+            nbytes += 1
+        # Construct memoryview object and a view for each field
+        self._mem = memoryview((ctypes.c_uint8 * nbytes)()).cast("B")
+        self._views = {}
+        for name, format, i1, i2 in fields:
+            self._views[name] = self._mem[i1:i2].cast(format)
+
+    @property
+    def mem(self):
+        return self._mem
+
+    @property
+    def nbytes(self):
+        return self._mem.nbytes
+
+    def __getitem__(self, key):
+        v = self._views[key].tolist()
+        return v[0] if len(v) == 1 else v
+
+    def __setitem__(self, key, val):
+        m = self._views[key]
+        n = m.shape[0]
+        if n == 1:
+            assert isinstance(val, (float, int))
+            m[0] = val
+        else:
+            assert isinstance(val, (tuple, list))
+            for i in range(n):
+                m[i] = val[i]


### PR DESCRIPTION
Very WIP, so the branch is messy. Mentioned in #8

I threw this together at the airport just now after thinking about it for the past week. 

Currently works with the example provided but theoretically should work with all single pass shaders. 
Only float and int dtypes and only glsl just now. Also missing common code. 

Based on the imgui example in wgpu, but I can already think of a bunch of ways to make it fit better with the existing structures. 

most likely todos:
* [x] better example, perhaps this: https://www.shadertoy.com/view/Wf3SWn (needs to loop in L73)
* [ ] can we somehow access the preprocessor from naga (or via tree-sitter?)
* [x] add a dataclass to hold all the information
* [x] support common and buffer passes like `buffer_a.value`
* [ ] can imgui be it's own renderpass (instead of attaching to the image?)
* [x] Sliders should have an option to reset to default
* [x] Print the value off all constants upon exit (`on_close` event?)
* [ ] skip common constants (pi, tau, eps?, ...)
* [ ] vec3 dtype for color picker and directions!?
* [ ] can we get `const float name 1.23` too?
* [ ] a bunch of tests
* [ ] should this be an optional dependency
* [ ] does imgui-bundle work with python3.9 or do we need to drop it?
* [ ] WGSL has no `#define` - do we support any patterns there?
* [ ] cleanup