### PR TITLE
Fix GUI scaling

### DIFF
--- a/examples/shadertoy_glsl_mouse_event.py
+++ b/examples/shadertoy_glsl_mouse_event.py
@@ -60,7 +60,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 }
 
 """
-shader = Shadertoy(shader_code)
+shader = Shadertoy(shader_code, resolution=(800, 450))
 
 if __name__ == "__main__":
     shader.show()

--- a/wgpu_shadertoy/shadertoy.py
+++ b/wgpu_shadertoy/shadertoy.py
@@ -100,7 +100,6 @@ class Shadertoy:
     """
 
     # todo: add remaining built-in variables (i_channel_time)
-    # todo: support multiple render passes (`i_channel0`, `i_channel1`, etc.)
 
     def __init__(
         self,
@@ -222,7 +221,7 @@ class Shadertoy:
             self._canvas = WgpuCanvas(
                 title=self.title, size=self.resolution, max_fps=60
             )
-
+        self._uniform_data["resolution"][2] = self._canvas.get_pixel_ratio()
         self._present_context = self._canvas.get_context()
 
         # We use non srgb variants, because we want to let the shader fully control the color-space.
@@ -236,8 +235,8 @@ class Shadertoy:
 
     def _bind_events(self):
         def on_resize(event):
-            w, h = event["width"], event["height"]
-            self._uniform_data["resolution"] = (w, h, 1)
+            w, h, ratio = event["width"], event["height"], event["pixel_ratio"]
+            self._uniform_data["resolution"] = (w, h, ratio)
             for buf in self.buffers.values():
                 # TODO: do we want to call this every single time or only when the resize is done?
                 # render loop is suspended during any window interaction anyway - will be fixed with rendercanvas: https://github.com/pygfx/rendercanvas/issues/69


### PR DESCRIPTION
There is two issue when using OS scaling (like 125% on windows):

The ImagePass uses the physical size due to how it's handled internally in wgpu for `get_current_texture`: 

https://github.com/pygfx/wgpu-py/blob/d25edb102644f74c0d12e24996f757eac77b57fa/wgpu/backends/wgpu_native/_api.py#L886

However then the buffer passes use the `self.resolution`, as in the logical size the user requested. This missmatch causes a few issues where absolute pixel values were used, such as the simple buffer feedback example (but it could be something interesting in the future where some passes use different resolutions).
I considered somehow forcing it to use logical size instead (as in ignore scaling) but couldn't see a direct path.

the 2nd issue was due to mouse events not lining up... but only in the image pass which caused some confusion further down when different passes used mouse events. One such example is https://www.shadertoy.com/view/3fV3WV


The solution I came up with and that works on my machine (tried glfw and qt) is to just overwrite the user input with the physical size. This might not match expectations, but it works easily enough. Also requires additional multiplication for the events... which all return logical size. (Some of this handling could be moved into the shader or the update function - should we eventually allow mixing multiple resolutions)

